### PR TITLE
Generate CNAME file for custom domain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ if(DOXYGEN_FOUND)
   add_custom_target(toolbox-doc
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     COMMAND "${DOXYGEN_EXECUTABLE}" "${PROJECT_BINARY_DIR}/Doxyfile"
+    COMMAND "${CMAKE_COMMAND}" -E echo doc.toolbox.reactivemarkets.com
+           >"${PROJECT_BINARY_DIR}/doc/html/CNAME"
     SOURCES "${PROJECT_BINARY_DIR}/Doxyfile")
 
   add_dependencies(toolbox-doc toolbox-image)


### PR DESCRIPTION
Generate CNAME file on the gh-pages branch. This is required to enable use of a custom DNS domain for Doxygen documentation hosted on GitHub pages.