### PR TITLE
DNS resolver crashes in GCC 9.1

### DIFF
--- a/toolbox/net/Resolver.cpp
+++ b/toolbox/net/Resolver.cpp
@@ -37,7 +37,7 @@ int Resolver::run(Duration timeout)
         return -1;
     }
     // Copy batch of tasks to temporary buffer.
-    Task tasks[BatchSize];
+    std::array<Task, BatchSize> tasks{};
 
     const auto n = std::min(queue_.size(), BatchSize);
     for (std::size_t i{0}; i < n; ++i) {


### PR DESCRIPTION
GCC 9.1 exposed a dormant bug in the DNS resolver that causes the run loop to crash when clearing tasks from the queue. The crash was caused by accessing uninitialised elements of a local array.