### PR TITLE
Generalise JSON exception format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,21 @@ The seven rules of a great git commit message:
 
 See [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/) by Chris Beams.
 
+## Issue References
+
+GitHub issue numbers should be referenced on the last line of the commit message. Keywords can be
+used to [automatically close
+issues](https://help.github.com/en/articles/closing-issues-using-keywords). For example:
+
+```
+The Subject Line
+
+A more detailed description that explains what the change is,
+why it is needed, and how it has been implemented.
+
+Closes #123, #456
+```
+
 ## Pull Requests
 
 We actively welcome your pull requests.

--- a/toolbox/util/Exception.cpp
+++ b/toolbox/util/Exception.cpp
@@ -44,11 +44,10 @@ Exception::Exception(int err, const error_category& ecat, std::string_view what)
 
 Exception::~Exception() = default;
 
-void Exception::to_json(ostream& os, int status_code, const char* status, const char* message)
+void Exception::to_json(ostream& os, int code, const char* message)
 {
-    os << "{\"status_code\":" << status_code //
-       << ",\"status\":\"" << status         //
-       << "\",\"message\":\"" << message     //
+    os << "{\"code\":" << code         //
+       << ",\"message\":\"" << message //
        << "\"}";
 }
 

--- a/toolbox/util/Exception.hpp
+++ b/toolbox/util/Exception.hpp
@@ -45,8 +45,26 @@ class TOOLBOX_API Exception : public std::runtime_error {
     Exception(Exception&&) = default;
     Exception& operator=(Exception&&) = default;
 
-    static void to_json(std::ostream& os, int status_code, const char* status, const char* message);
+    /// Format exception as a OpenAPI JSON response message.
+    /// \param os The output stream.
+    /// \param code The error code.
+    /// \param message The error Message.
+    static void to_json(std::ostream& os, int code, const char* message);
 
+    /// Format exception as a OpenAPI JSON response message.
+    /// \param os The output stream.
+    /// \param code The error code.
+    /// \param message The error Message.
+    static void to_json(std::ostream& os, const std::error_code& code, const char* message)
+    {
+        to_json(os, code.value(), message);
+    }
+
+    /// Format exception as a OpenAPI JSON response message.
+    /// \param os The output stream.
+    void to_json(std::ostream& os) const { to_json(os, ec_, what()); }
+
+    /// Returns the error code.
     const std::error_code& code() const noexcept { return ec_; }
 
   private:

--- a/toolbox/util/Exception.ut.cpp
+++ b/toolbox/util/Exception.ut.cpp
@@ -25,9 +25,23 @@ BOOST_AUTO_TEST_SUITE(ExceptionSuite)
 BOOST_AUTO_TEST_CASE(ExceptionCase)
 {
     const auto ec = std::make_error_code(std::errc::invalid_argument);
-    const Exception e{ec, "foo"};
-    BOOST_TEST(e.what() == std::strerror(EINVAL) + std::string{": foo"});
+    const Exception e{ec, "foobar error"};
+    BOOST_TEST(e.what() == std::strerror(EINVAL) + std::string{": foobar error"});
     BOOST_TEST(e.code() == ec);
+}
+
+BOOST_AUTO_TEST_CASE(ExceptionToJsonCase)
+{
+    const auto ec = std::make_error_code(std::errc::invalid_argument);
+    const Exception e{ec, "foobar error"};
+
+    std::stringstream ss;
+    e.to_json(ss);
+
+    BOOST_TEST(ss.str() == //
+               "{\"code\":22"
+               ",\"message\":\"Invalid argument: foobar error\""
+               "}");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Although the Exception class is designed to represent different kinds of exception, the current JSON format is quite specific to HTTP. The format should be generalised and brought more in line with the emerging OpenAPI standard.

Closes #27
