### PR TITLE
GH-30 Benchmarking functionality

### DIFF
--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -92,6 +92,7 @@ set(lib_SOURCES
   sys/Time.cpp
   sys/Thread.cpp
   util/Array.cpp
+  util/Benchmark.cpp
   util/Compare.cpp
   util/Config.cpp
   util/Enum.cpp
@@ -225,3 +226,9 @@ foreach(file ${test_SOURCES})
   get_filename_component(name "${file}" NAME_WE)
   add_test(NAME ${dir}::${name}Suite COMMAND toolbox-test -l error -t ${name}Suite)
 endforeach()
+
+add_executable(toolbox-bench
+  util/Utility.bm.cpp
+)
+
+target_link_libraries(toolbox-bench ${toolbox_LIBRARY})

--- a/toolbox/util/Benchmark.cpp
+++ b/toolbox/util/Benchmark.cpp
@@ -1,0 +1,107 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "Benchmark.hpp"
+
+#include <toolbox/sys/Options.hpp>
+
+#include <random>
+#include <regex>
+
+namespace toolbox {
+inline namespace benchmark {
+
+Runnable::~Runnable() = default;
+
+BenchmarkStore& BenchmarkStore::instance()
+{
+    static BenchmarkStore store;
+    return store;
+}
+
+void BenchmarkStore::store(const char* name, Runnable& runnable)
+{
+    store_.insert_or_assign(name, &runnable);
+}
+
+void BenchmarkStore::list() const
+{
+    for (const auto& runnable : store_) {
+        std::cout << runnable.first << '\n';
+    }
+}
+
+void BenchmarkStore::run(const std::string& regex_str, bool randomise)
+{
+    std::vector<Runnable*> filtered;
+
+    std::regex regex{regex_str};
+    for (const auto& runnable : store_) {
+        if (std::regex_search(runnable.first, regex)) {
+            filtered.push_back(runnable.second);
+        }
+    }
+
+    if (randomise) {
+        auto rng = std::default_random_engine{};
+        std::shuffle(std::begin(filtered), std::end(filtered), rng);
+    }
+
+    if (!filtered.empty()) {
+        // Print header
+        std::cout << "Benchmark  Average(ns)  Runs Time(us)\n";
+        for (auto* test : filtered) {
+            test->run();
+        }
+    }
+}
+
+BenchmarkStore::BenchmarkStore() = default;
+
+namespace detail {
+int main(int argc, char* argv[])
+{
+    std::string regex;
+    bool list{false};
+    bool randomise{false};
+
+    Options opts{"Benchmark options [OPTIONS] [COMMAND]"};
+    // clang-format off
+    opts('f', "filter", Value{regex}, "Run only matches of regex")
+        ('l', "list", Switch{list}, "List available benchmarks")
+        ('h', "help", Help{})
+        ('r', "random", Switch{randomise}, "Run tests in random order")
+    ;
+    // clang-format on
+
+    try {
+        opts.parse(argc, argv);
+    } catch (const std::runtime_error& ex) {
+        std::cerr << opts;
+        return 1;
+    }
+
+    auto& store = BenchmarkStore::instance();
+    if (list) {
+        store.list();
+        return 0;
+    }
+
+    store.run(regex, randomise);
+    return 0;
+}
+} // namespace detail
+
+} // namespace benchmark
+} // namespace toolbox

--- a/toolbox/util/Benchmark.hpp
+++ b/toolbox/util/Benchmark.hpp
@@ -1,0 +1,225 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOOLBOX_UTIL_BENCHMARK_HPP
+#define TOOLBOX_UTIL_BENCHMARK_HPP
+
+#include <toolbox/Config.h>
+
+#include "Traits.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <thread>
+
+#include <unistd.h>
+
+namespace toolbox {
+inline namespace benchmark {
+
+// The clobber and use functions below are used to defeat the optimiser.
+// See CppCon 2015: Chandler Carruth "Tuning C++: Benchmarks, and CPUs, and Compilers! Oh My!"
+// And https://github.com/google/benchmark/blob/master/include/benchmark/benchmark.h
+
+/// The clobber function instructs the compiler that something might have changed in the memory and
+/// no assumptions can be made that would discard memory writes.
+inline void clobber() noexcept
+{
+    asm volatile("" ::: "memory");
+}
+
+/// The use function emulates the creation additional uses of the reference essentially instructing
+/// the compiler that pointers in it's scope are now available to call though global pointers.
+template <typename ValueT>
+inline void use(const ValueT& val) noexcept
+{
+    asm volatile("" : : "r,m"(val) : "memory");
+}
+
+/// The use function emulates the creation additional uses of the reference essentially instructing
+/// the compiler that pointers in it's scope are now available to call though global pointers.
+template <typename ValueT>
+inline void use(ValueT& val) noexcept
+{
+#if defined(__clang__)
+    asm volatile("" : "+r,m"(val) : : "memory");
+#else
+    asm volatile("" : "+m,r"(val) : : "memory");
+#endif
+}
+
+struct TOOLBOX_API Runnable {
+    virtual ~Runnable();
+    virtual void run() = 0;
+};
+
+class TOOLBOX_API BenchmarkStore {
+  public:
+    static BenchmarkStore& instance();
+
+    void store(const char* name, Runnable& runnable);
+    void list() const;
+
+    void run(const std::string& regex, bool randomise);
+
+  private:
+    BenchmarkStore();
+    BenchmarkStore(const BenchmarkStore&) = delete;
+
+    std::map<const char*, Runnable*> store_;
+};
+
+template <typename FuncT, class Enable = void>
+class BenchmarkCaller {
+  public:
+    BenchmarkCaller(FuncT& func)
+    : func_{func}
+    {
+    }
+
+    void operator()() { func_(); }
+
+    int calls_per_execution() const noexcept { return 1; }
+
+  private:
+    FuncT& func_;
+};
+
+template <typename FuncT>
+class BenchmarkCaller<FuncT, typename std::enable_if_t<FunctionTraits<FuncT>::Arity>> {
+  public:
+    BenchmarkCaller(FuncT& func)
+    : func_{func}
+    {
+    }
+
+    void operator()()
+    {
+        for (auto curr = start; curr < end; ++curr) {
+            use(func_(curr));
+            clobber();
+        }
+    }
+
+    auto calls_per_execution() const noexcept { return end - start; }
+
+  private:
+    FuncT func_;
+    using Traits = FunctionTraits<FuncT>;
+    using RangeType = typename Traits::template ArgType<0>;
+
+  public:
+    RangeType start;
+    RangeType end;
+};
+
+template <typename FuncT>
+class Benchmark : public Runnable {
+
+  public:
+    Benchmark() = delete;
+
+    Benchmark(Benchmark&& b)
+    : name_{b.name_}
+    , func_{b.func_}
+    {
+        BenchmarkStore::instance().store(name_, *this);
+    }
+
+    Benchmark(const char* name, FuncT func)
+    : name_{name}
+    , func_{func}
+    {
+        BenchmarkStore::instance().store(name_, *this);
+    }
+
+    // Chaining breaks the lifetime extension of the rvalue and since we register the address in the
+    // store in the constructor chaining methods need to return move, and move constructors also
+    // register overriding the pointer value in the store.
+    template <typename FromT, typename ToT>
+        Benchmark range(const FromT& from, const ToT& to) && noexcept
+    {
+        func_.start = from;
+        func_.end = to;
+        return std::move(*this);
+    }
+
+    template <typename ValueT>
+        Benchmark value(const ValueT& val) && noexcept
+    {
+        func_.start = val;
+        // TODO: this should be a different type.
+        func_.end = val + 1;
+        return std::move(*this);
+    }
+
+    void run() override final
+    {
+        using namespace std::literals::chrono_literals;
+
+        constexpr auto sleep = 2s;
+
+        // Warmup get clock timings.
+        // Measure single call.
+        std::atomic_bool done{false};
+        std::thread t([&]() {
+            std::this_thread::sleep_for(sleep);
+            done = true;
+        });
+        int runs{0};
+        while (!done) {
+            func_();
+            runs++;
+        }
+        t.join();
+
+        const long long expected_seconds{3};
+        const long long n_calls = expected_seconds * runs / sleep.count();
+        auto start_check = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < n_calls; ++i) {
+            func_();
+        }
+        auto end_check = std::chrono::high_resolution_clock::now();
+        auto end_diff
+            = std::chrono::duration_cast<std::chrono::nanoseconds>(end_check - start_check);
+        std::cout << name_ << ' ' << end_diff.count() / (n_calls * func_.calls_per_execution())
+                  << ' ' << n_calls << ' '
+                  << std::chrono::duration_cast<std::chrono::microseconds>(end_diff).count()
+                  << '\n';
+    }
+
+    const char* name_;
+
+    BenchmarkCaller<FuncT> func_;
+};
+
+namespace detail {
+TOOLBOX_API int main(int argc, char* argv[]);
+}
+
+} // namespace benchmark
+} // namespace toolbox
+
+#define TOOLBOX_BENCHMARK_OP_2(Count) reg_##Count
+#define TOOLBOX_BENCHMARK_OP_1(Name, Func, Value)                                                  \
+    static const auto& TOOLBOX_BENCHMARK_OP_2(Value) = toolbox::benchmark::Benchmark { Name, Func }
+#define TOOLBOX_BENCHMARK(Name, Func) TOOLBOX_BENCHMARK_OP_1(Name, Func, __COUNTER__)
+
+#define TOOLBOX_BENCHMARK_MAIN()                                                                   \
+    int main(int argc, char* argv[]) { return toolbox::benchmark::detail::main(argc, argv); }
+
+#endif // TOOLBOX_UTIL_BENCHMARK_HPP

--- a/toolbox/util/Traits.hpp
+++ b/toolbox/util/Traits.hpp
@@ -45,6 +45,11 @@ struct FunctionTraits<ReturnT (*)(ArgsT...)> {
     using Pack = TemplT<ArgsT...>;
 };
 
+/// Specialisation for noexcept free functions.
+template <typename ReturnT, typename... ArgsT>
+struct FunctionTraits<ReturnT (*)(ArgsT...) noexcept> : FunctionTraits<ReturnT (*)(ArgsT...)> {
+};
+
 /// Specialisation for member functions.
 template <typename ClassT, typename ReturnT, typename... ArgsT>
 struct FunctionTraits<ReturnT (ClassT::*)(ArgsT...)> : FunctionTraits<ReturnT (*)(ArgsT...)> {

--- a/toolbox/util/Utility.bm.cpp
+++ b/toolbox/util/Utility.bm.cpp
@@ -1,0 +1,150 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Utility.hpp"
+
+#include "Benchmark.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <list>
+#include <numeric>
+#include <thread>
+#include <vector>
+
+#include <sys/time.h>
+
+using namespace std;
+using namespace toolbox;
+
+namespace {
+
+int dec_digits2(int64_t i) noexcept __attribute__((noinline));
+int dec_digits2(int64_t i) noexcept
+{
+    int count = 0;
+    do {
+        i = i / 10;
+        ++count;
+    } while (i != 0);
+    return count;
+}
+
+int dec_digits3(int64_t i) noexcept __attribute__((noinline));
+int dec_digits3(int64_t i) noexcept
+{
+    return i ? floor(log10(i) + 1) : 1;
+}
+
+int dec_digits4(int64_t i) noexcept __attribute__((noinline));
+int dec_digits4(int64_t i) noexcept
+{
+    return snprintf(nullptr, 0, "%lu", i);
+}
+
+int dec_digits5(int64_t i) noexcept __attribute__((noinline));
+int dec_digits5(int64_t i) noexcept
+{
+    if (i < 10)
+        return 1;
+    if (i < 100)
+        return 2;
+    if (i < 1000)
+        return 3;
+    if (i < 10000)
+        return 4;
+    if (i < 100000)
+        return 5;
+    if (i < 1000000)
+        return 6;
+    if (i < 10000000)
+        return 7;
+    if (i < 100000000)
+        return 8;
+    if (i < 1000000000)
+        return 9;
+    if (i < 10000000000)
+        return 10;
+    if (i < 100000000000)
+        return 11;
+    if (i < 1000000000000)
+        return 12;
+    if (i < 10000000000000)
+        return 13;
+    if (i < 100000000000000)
+        return 14;
+    if (i < 1000000000000000)
+        return 15;
+    if (i < 10000000000000000)
+        return 16;
+    if (i < 100000000000000000)
+        return 17;
+    if (i < 1000000000000000000)
+        return 18;
+    return 19;
+}
+
+int hex_digits2(int64_t i) noexcept __attribute__((noinline));
+int hex_digits2(int64_t i) noexcept
+{
+    int n{0};
+    if (i & 0xffffffff00000000) {
+        n += 8;
+        i >>= 32;
+    }
+    if (i & 0xffff0000) {
+        n += 4;
+        i >>= 16;
+    }
+    if (i & 0xff00) {
+        n += 2;
+        i >>= 8;
+    }
+    if (i & 0xf0) {
+        n += 2;
+    } else if (i & 0x0f) {
+        ++n;
+    }
+    return n;
+}
+
+} // namespace
+
+TOOLBOX_BENCHMARK("isdigit/toolbox", [](int64_t i) {
+    return toolbox::util::isdigit(i);
+}).range(0, 1000);
+TOOLBOX_BENCHMARK("isdigit/std", [](int64_t i) { return std::isdigit(i); }).range(0, 1000);
+
+TOOLBOX_BENCHMARK("conversion/int_to_string", [](int x) {
+    return std::to_string(x);
+}).range(0, 10000);
+TOOLBOX_BENCHMARK("conversion/double_to_string", [](double x) {
+    return std::to_string(x);
+}).range(0.0, 10000.0);
+
+struct timeval tv;
+TOOLBOX_BENCHMARK("time/gettimeofday", []() { gettimeofday(&tv, nullptr); });
+
+TOOLBOX_BENCHMARK("util/dec_digits1", dec_digits).range(0, 400000);
+TOOLBOX_BENCHMARK("util/dec_digits2", dec_digits2).range(0, 400000);
+TOOLBOX_BENCHMARK("util/dec_digits3", dec_digits3).range(0, 400000);
+TOOLBOX_BENCHMARK("util/dec_digits4", dec_digits4).range(0, 400000);
+TOOLBOX_BENCHMARK("util/dec_digits5", dec_digits5).range(0, 400000);
+TOOLBOX_BENCHMARK("util/dec_digits5", dec_digits5).range(0, 400000);
+
+TOOLBOX_BENCHMARK("util/hex_digits1", hex_digits).range(0, 400000);
+TOOLBOX_BENCHMARK("util/hex_digits2", hex_digits2).range(0, 400000);
+
+TOOLBOX_BENCHMARK_MAIN()

--- a/toolbox/util/Utility.cpp
+++ b/toolbox/util/Utility.cpp
@@ -23,27 +23,38 @@ namespace toolbox {
 inline namespace util {
 using namespace std;
 
+int dec_digits(int64_t i) noexcept
+{
+    return i < 10000000000 ? i < 100000
+            ? i < 100 ? i < 10 ? 1 : 2 : i < 1000 ? 3 : i < 10000 ? 4 : 5
+            : i < 10000000 ? i < 1000000 ? 6 : 7 : i < 100000000 ? 8 : i < 1000000000 ? 9 : 10
+                           : i < 1000000000000000
+            ? i < 1000000000000 ? i < 100000000000 ? 11 : 12
+                                : i < 10000000000000 ? 13 : i < 100000000000000 ? 14 : 15
+            : i < 100000000000000000 ? i < 10000000000000000 ? 16 : 17
+                                     : i < 1000000000000000000 ? 18 : 19;
+}
+
 int hex_digits(int64_t i) noexcept
 {
-    int n{0};
-    if (i & 0xffffffff00000000) {
-        n += 8;
-        i >>= 32;
-    }
-    if (i & 0xffff0000) {
-        n += 4;
-        i >>= 16;
-    }
-    if (i & 0xff00) {
-        n += 2;
-        i >>= 8;
-    }
-    if (i & 0xf0) {
-        n += 2;
-    } else if (i & 0x0f) {
-        ++n;
-    }
-    return n;
+    // clang-format off
+    return i & 0xffffffff00000000
+        ? i & 0xffff000000000000
+            ? i & 0xff00000000000000
+                ? i & 0xf000000000000000 ? 16:15
+                : i & 0x00f0000000000000 ? 14:13
+            : i & 0xff0000000000
+                ? i & 0xf00000000000 ? 12:11
+                : i & 0x00f000000000 ? 10:9
+        : i & 0xffff0000
+            ? i & 0xff000000
+                ? i & 0xf0000000 ? 8:7
+                : i & 0x00f00000 ? 6:5
+            : i & 0xff00
+                ? i & 0xf000 ? 4:3
+                : i & 0x00f0 ? 2:1
+        ;
+    // clang-format on
 }
 
 bool stob(string_view sv, bool dfl) noexcept

--- a/toolbox/util/Utility.hpp
+++ b/toolbox/util/Utility.hpp
@@ -42,6 +42,7 @@ constexpr bool isdigit(int c) noexcept
 }
 static_assert(isdigit('0') && isdigit('9') && !isdigit('A'));
 
+TOOLBOX_API int dec_digits(int64_t i) noexcept;
 TOOLBOX_API int hex_digits(int64_t i) noexcept;
 
 TOOLBOX_API bool stob(std::string_view sv, bool dfl = false) noexcept;

--- a/toolbox/util/Utility.ut.cpp
+++ b/toolbox/util/Utility.ut.cpp
@@ -132,6 +132,7 @@ BOOST_AUTO_TEST_CASE(Stou64Case)
 
 BOOST_AUTO_TEST_CASE(HexDigitsCase)
 {
+    BOOST_TEST(hex_digits(0x0) == 1);
     BOOST_TEST(hex_digits(0x1) == 1);
     BOOST_TEST(hex_digits(0xf) == 1);
     BOOST_TEST(hex_digits(0x10) == 2);
@@ -144,6 +145,30 @@ BOOST_AUTO_TEST_CASE(HexDigitsCase)
     BOOST_TEST(hex_digits(0x567890abcdef) == 12);
     BOOST_TEST(hex_digits(0x1000000000000) == 13);
     BOOST_TEST(hex_digits(0x1234567890abcdef) == 16);
+}
+
+BOOST_AUTO_TEST_CASE(DecDigitsCase)
+{
+    BOOST_TEST(dec_digits(0) == 1);
+    BOOST_TEST(dec_digits(1) == 1);
+    BOOST_TEST(dec_digits(10) == 2);
+    BOOST_TEST(dec_digits(100) == 3);
+    BOOST_TEST(dec_digits(1000) == 4);
+    BOOST_TEST(dec_digits(10000) == 5);
+    BOOST_TEST(dec_digits(100000) == 6);
+    BOOST_TEST(dec_digits(1000000) == 7);
+    BOOST_TEST(dec_digits(10000000) == 8);
+    BOOST_TEST(dec_digits(100000000) == 9);
+    BOOST_TEST(dec_digits(1000000000) == 10);
+    BOOST_TEST(dec_digits(10000000000) == 11);
+    BOOST_TEST(dec_digits(100000000000) == 12);
+    BOOST_TEST(dec_digits(1000000000000) == 13);
+    BOOST_TEST(dec_digits(10000000000000) == 14);
+    BOOST_TEST(dec_digits(100000000000000) == 15);
+    BOOST_TEST(dec_digits(1000000000000000) == 16);
+    BOOST_TEST(dec_digits(10000000000000000) == 17);
+    BOOST_TEST(dec_digits(100000000000000000) == 18);
+    BOOST_TEST(dec_digits(1000000000000000000) == 19);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add basic benchmarking mechanism, with an emphasis on microbenchmarks.

Basic usage:

```bash
# Run all benchmarks
bin/toolbox-bench | column -t

# Filter (regex)
bin/toolbox-bench --filter hex | column -t

# Randomize order
bin/toolbox-bench --filter hex --random | column -t
```