### PR TITLE
Improve socket option support

### DIFF
--- a/example/EchoClnt.cpp
+++ b/example/EchoClnt.cpp
@@ -123,7 +123,8 @@ class EchoClnt : public StreamConnector<EchoClnt> {
     }
 
   private:
-    void do_connect(CyclTime now, IoSock&& sock, const Endpoint& ep)
+    void on_sock_init(CyclTime now, IoSock& sock) {}
+    void on_sock_connect(CyclTime now, IoSock&& sock, const Endpoint& ep)
     {
         TOOLBOX_INFO << "connection opened: " << ep;
         inprogress_ = false;
@@ -132,7 +133,7 @@ class EchoClnt : public StreamConnector<EchoClnt> {
         auto* const conn = new EchoConn{now, reactor_, move(sock), ep};
         conn_list_.push_back(*conn);
     }
-    void do_connect_error(CyclTime now, const std::exception& e)
+    void on_sock_connect_error(CyclTime now, const std::exception& e)
     {
         TOOLBOX_ERROR << "failed to connect: " << e.what();
         aifuture_ = resolver_.resolve(uri_, SOCK_STREAM);

--- a/example/EchoServ.cpp
+++ b/example/EchoServ.cpp
@@ -121,14 +121,11 @@ class EchoServ : public StreamAcceptor<EchoServ> {
     }
 
   private:
-    void do_accept(CyclTime now, IoSock&& sock, const Endpoint& ep)
+    void on_sock_init(CyclTime now, IoSock& sock) {}
+    void on_sock_accept(CyclTime now, IoSock&& sock, const Endpoint& ep)
     {
         TOOLBOX_INFO << "connection opened: " << ep;
 
-        sock.set_non_block();
-        if (sock.is_ip_family()) {
-            set_tcp_no_delay(sock.get(), true);
-        }
         // High performance TCP servers could use a custom allocator.
         auto* const conn = new EchoConn{now, reactor_, move(sock), ep};
         conn_list_.push_back(*conn);

--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -42,21 +42,21 @@ class HttpApp : public HttpAppBase {
     void bind(const std::string& path, Slot slot) { slot_map_[path] = slot; }
 
   protected:
-    void do_on_connect(CyclTime now, const Endpoint& ep) noexcept override
+    void do_on_http_connect(CyclTime now, const Endpoint& ep) noexcept override
     {
         TOOLBOX_INFO << "http session connected: " << ep;
     }
-    void do_on_disconnect(CyclTime now, const Endpoint& ep) noexcept override
+    void do_on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept override
     {
         TOOLBOX_INFO << "http session disconnected: " << ep;
     }
-    void do_on_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                     HttpStream& os) noexcept override
+    void do_on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
+                          HttpStream& os) noexcept override
     {
-        TOOLBOX_ERROR << "session error: " << ep << ": " << e.what();
+        TOOLBOX_ERROR << "http session error: " << ep << ": " << e.what();
     }
-    void do_on_message(CyclTime now, const Endpoint& ep, const HttpRequest& req,
-                       HttpStream& os) override
+    void do_on_http_message(CyclTime now, const Endpoint& ep, const HttpRequest& req,
+                            HttpStream& os) override
     {
         const auto it = slot_map_.find(string{req.path()});
         if (it != slot_map_.end()) {
@@ -68,9 +68,9 @@ class HttpApp : public HttpAppBase {
         }
         os.commit();
     }
-    void do_on_timeout(CyclTime now, const Endpoint& ep) noexcept override
+    void do_on_http_timeout(CyclTime now, const Endpoint& ep) noexcept override
     {
-        TOOLBOX_WARNING << "session timeout: " << ep;
+        TOOLBOX_WARNING << "http session timeout: " << ep;
     }
 
   private:

--- a/toolbox/http/App.hpp
+++ b/toolbox/http/App.hpp
@@ -43,29 +43,32 @@ class TOOLBOX_API HttpAppBase {
     constexpr HttpAppBase(HttpAppBase&&) noexcept = default;
     HttpAppBase& operator=(HttpAppBase&&) noexcept = default;
 
-    void on_connect(CyclTime now, const Endpoint& ep) { do_on_connect(now, ep); }
-    void on_disconnect(CyclTime now, const Endpoint& ep) noexcept { do_on_disconnect(now, ep); }
-    void on_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                  HttpStream& os) noexcept
+    void on_http_connect(CyclTime now, const Endpoint& ep) { do_on_http_connect(now, ep); }
+    void on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept
     {
-        do_on_error(now, ep, e, os);
+        do_on_http_disconnect(now, ep);
     }
-    void on_message(CyclTime now, const Endpoint& ep, const HttpRequest& req, HttpStream& os)
+    void on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
+                       HttpStream& os) noexcept
     {
-        do_on_message(now, ep, req, os);
+        do_on_http_error(now, ep, e, os);
     }
-    void on_timeout(CyclTime now, const Endpoint& ep) noexcept { do_on_timeout(now, ep); }
+    void on_http_message(CyclTime now, const Endpoint& ep, const HttpRequest& req, HttpStream& os)
+    {
+        do_on_http_message(now, ep, req, os);
+    }
+    void on_http_timeout(CyclTime now, const Endpoint& ep) noexcept { do_on_http_timeout(now, ep); }
 
   protected:
-    virtual void do_on_connect(CyclTime now, const Endpoint& ep) = 0;
-    virtual void do_on_disconnect(CyclTime now, const Endpoint& ep) noexcept = 0;
-    virtual void do_on_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                             HttpStream& os) noexcept
+    virtual void do_on_http_connect(CyclTime now, const Endpoint& ep) = 0;
+    virtual void do_on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept = 0;
+    virtual void do_on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
+                                  HttpStream& os) noexcept
         = 0;
-    virtual void do_on_message(CyclTime now, const Endpoint& ep, const HttpRequest& req,
-                               HttpStream& os)
+    virtual void do_on_http_message(CyclTime now, const Endpoint& ep, const HttpRequest& req,
+                                    HttpStream& os)
         = 0;
-    virtual void do_on_timeout(CyclTime now, const Endpoint& ep) noexcept = 0;
+    virtual void do_on_http_timeout(CyclTime now, const Endpoint& ep) noexcept = 0;
 };
 
 } // namespace http

--- a/toolbox/http/Serv.hpp
+++ b/toolbox/http/Serv.hpp
@@ -60,7 +60,8 @@ class BasicHttpServ : public StreamAcceptor<BasicHttpServ<ConnT, AppT>> {
     BasicHttpServ& operator=(BasicHttpServ&&) = delete;
 
   private:
-    void do_accept(CyclTime now, IoSock&& sock, const Endpoint& ep)
+    void on_sock_init(CyclTime now, IoSock& sock) {}
+    void on_sock_accept(CyclTime now, IoSock&& sock, const Endpoint& ep)
     {
         auto* const conn = new Conn{now, reactor_, std::move(sock), ep, app_};
         conn_list_.push_back(*conn);

--- a/toolbox/net/StreamConnector.hpp
+++ b/toolbox/net/StreamConnector.hpp
@@ -47,6 +47,7 @@ class StreamConnector {
     bool connect(CyclTime now, Reactor& r, const Endpoint& ep)
     {
         StreamSockClnt sock{ep.protocol()};
+        static_cast<DerivedT*>(this)->on_sock_init(now, sock);
         sock.set_non_block();
         if (sock.is_ip_family()) {
             set_tcp_no_delay(sock.get(), true);
@@ -64,7 +65,7 @@ class StreamConnector {
             sock_ = std::move(sock);
             return false;
         }
-        static_cast<DerivedT*>(this)->do_connect(now, std::move(sock), ep);
+        static_cast<DerivedT*>(this)->on_sock_connect(now, std::move(sock), ep);
         return true;
     }
 
@@ -77,13 +78,13 @@ class StreamConnector {
         IoSock sock{std::move(sock_)};
         sub_.reset();
         try {
-            const auto ec = sock.get_so_error();
+            const auto ec = sock.get_error();
             if (ec) {
                 throw std::system_error{ec, "connect"};
             }
-            static_cast<DerivedT*>(this)->do_connect(now, std::move(sock), ep_);
+            static_cast<DerivedT*>(this)->on_sock_connect(now, std::move(sock), ep_);
         } catch (const std::exception& e) {
-            static_cast<DerivedT*>(this)->do_connect_error(now, e);
+            static_cast<DerivedT*>(this)->on_sock_connect_error(now, e);
         }
     }
 


### PR DESCRIPTION
Add new `on_sock_init` lifecycle callback, so that applications are given an opportunity to set socket options such as `SO_RCVBUF` and `SO_SNDBUF`.

This change also includes refactoring to make callback naming conventions clearer and more consistent.

Closes #35