### PR TITLE
Add initial version of HdrHistogram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .editorconfig
 .vscode
 /.idea/
+*.kdev4
 
 # OSX.
 .DS_Store
@@ -10,3 +11,4 @@
 # Build.
 *.pyc
 cmake-build-*/
+build/

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -38,6 +38,8 @@ include_directories(SYSTEM
   "${CMAKE_CURRENT_SOURCE_DIR}/contrib")
 
 set(lib_SOURCES
+  hdr/HdrHistogram.cpp
+  hdr/HdrHistogramIterator.cpp
   http/App.cpp
   http/Conn.cpp
   http/Error.cpp
@@ -129,6 +131,7 @@ if(TOOLBOX_BUILD_SHARED)
   install(TARGETS toolbox-shared DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT shared)
 endif()
 
+install(FILES hdr.hpp DESTINATION include/toolbox COMPONENT header)
 install(FILES http.hpp DESTINATION include/toolbox COMPONENT header)
 install(FILES io.hpp DESTINATION include/toolbox COMPONENT header)
 install(FILES ipc.hpp DESTINATION include/toolbox COMPONENT header)
@@ -177,6 +180,7 @@ endif()
 
 
 set(test_SOURCES
+  hdr/HdrHistogram.ut.cpp
   http/Parser.ut.cpp
   http/Types.ut.cpp
   http/Url.ut.cpp

--- a/toolbox/hdr.hpp
+++ b/toolbox/hdr.hpp
@@ -1,0 +1,22 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOOLBOX_HDR_HPP
+#define TOOLBOX_HDR_HPP
+
+#include "hdr/HdrHistogram.hpp"
+#include "hdr/HdrHistogramIterator.hpp"
+
+#endif // TOOLBOX_HDR_HPP

--- a/toolbox/hdr/HdrHistogram.cpp
+++ b/toolbox/hdr/HdrHistogram.cpp
@@ -1,0 +1,297 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "HdrHistogram.hpp"
+
+namespace {
+std::int64_t get_bucket_count(std::int64_t value, std::int64_t subb_count,
+                              std::int64_t unit_mag) noexcept
+{
+    auto smallest_untrackable_value = subb_count << unit_mag;
+    auto buckets_needed = 1;
+    while (smallest_untrackable_value <= value) {
+        if (smallest_untrackable_value > (std::numeric_limits<std::int64_t>::max() / 2)) {
+            return buckets_needed + 1;
+        }
+        smallest_untrackable_value <<= 1;
+        ++buckets_needed;
+    }
+    return buckets_needed;
+}
+
+std::int64_t init_sub_bucket_half_count_magnitude(std::int64_t significant_figures)
+{
+    double largest_value_single_unit_res = 2 * std::pow(10, significant_figures);
+    auto subb_count_mag = static_cast<std::int64_t>(
+        std::ceil(std::log(largest_value_single_unit_res) / std::log(2)));
+    return subb_count_mag > 1 ? subb_count_mag - 1 : 0;
+}
+
+} // namespace
+
+namespace toolbox {
+
+inline namespace hdr {
+
+HdrHistogram::HdrHistogram(std::int64_t lowest_value, std::int64_t highest_value,
+                           std::int64_t significant_figures)
+: unit_magnitude{static_cast<std::int64_t>(std::floor(std::log(lowest_value) / std::log(2)))}
+, sub_bucket_half_count_magnitude{init_sub_bucket_half_count_magnitude(significant_figures)}
+, sub_bucket_count(std::pow(2, sub_bucket_half_count_magnitude + 1))
+, sub_bucket_half_count{sub_bucket_count / 2}
+, sub_bucket_mask{(sub_bucket_count - 1) << unit_magnitude}
+, bucket_count{get_bucket_count(highest_value, sub_bucket_count, unit_magnitude)}
+, counts_len{(bucket_count + 1) * (sub_bucket_count / 2)}
+{
+    if (highest_value < 1) {
+        throw std::runtime_error{"Min value must be 1 or greater"};
+    }
+    if (significant_figures < 1 || significant_figures > 5) {
+        throw std::runtime_error{"SignificantFigures value must be between 1 and 5"};
+    }
+    counts_.resize(counts_len);
+}
+
+bool HdrHistogram::record(std::int64_t value, int count)
+{
+    auto counts_index = counts_index_for(value);
+    if (counts_len <= counts_index) {
+        return false;
+    }
+    counts_[counts_index] += count;
+    total_count_ += count;
+    min_value_ = std::min(min_value_, value);
+    max_value_ = std::max(max_value_, value);
+    return true;
+}
+
+std::int64_t HdrHistogram::percentile(double percentile) const noexcept
+{
+    auto count_at_percentile = get_target_count_at_percentile(percentile);
+    std::int64_t total = 0;
+    for (std::int64_t i = 0; i < counts_len; ++i) {
+        total += get_count_at_index(i);
+        if (total >= count_at_percentile) {
+            auto value_at_index = get_value_from_index(i);
+            return percentile ? get_highest_equivalent_value(value_at_index)
+                              : get_lowest_equivalent_value(value_at_index);
+        }
+    }
+    return 0;
+}
+
+std::int64_t HdrHistogram::values_are_equivalent(std::int64_t lhs, std::int64_t rhs)
+{
+    return get_lowest_equivalent_value(lhs) == get_lowest_equivalent_value(rhs);
+}
+
+std::int64_t HdrHistogram::max() const noexcept
+{
+    return max_value_ ? get_highest_equivalent_value(max_value_) : 0;
+}
+
+std::int64_t HdrHistogram::min() const noexcept
+{
+    if (total_count_ == 0 || counts_[0] > 0) {
+        return 0;
+    }
+    if (std::numeric_limits<std::int64_t>::max() == min_value_) {
+        return min_value_;
+    }
+    return get_lowest_equivalent_value(min_value_);
+}
+
+using RecordedIteratorAdapter = IteratorAdapter<RecordedIterator>;
+
+double HdrHistogram::mean() const noexcept
+{
+    if (!total_count_) {
+        return 0.0;
+    }
+    double total{0.0};
+    auto iter_adapter = RecordedIteratorAdapter(*this);
+    const auto& end = iter_adapter.end();
+    for (auto itr = iter_adapter.begin(); itr != end; ++itr) {
+        total += itr.get_count_at_this_value() * hdr_median_equiv_value(itr->value_iterated_to);
+    }
+    return total / total_count_;
+}
+
+double HdrHistogram::stddev() const noexcept
+{
+    if (!total_count_) {
+        return 0.0;
+    }
+    const auto mean_value = mean();
+    double geometric_dev_total{0.0};
+    for (const auto& item : RecordedIteratorAdapter(*this)) {
+        const auto dev = (hdr_median_equiv_value(item.value_iterated_to) * 1.0) - mean_value;
+        geometric_dev_total += (dev * dev) * item.count_added_in_this_iter_step;
+    }
+    return std::sqrt(geometric_dev_total / total_count_);
+}
+
+std::int64_t HdrHistogram::get_count_at_value(std::int64_t value) const noexcept
+{
+    auto counts_index = counts_index_for(value);
+    return counts_[counts_index];
+}
+
+std::int64_t HdrHistogram::get_total_count() const noexcept
+{
+    return total_count_;
+}
+
+std::int64_t HdrHistogram::get_highest_equivalent_value(std::int64_t value) const noexcept
+{
+    auto bucket_index = get_bucket_index(value);
+    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
+
+    auto lowest_equivalent_value = get_value_from_sub_bucket(bucket_index, sub_bucket_index);
+    if (sub_bucket_index >= sub_bucket_count) {
+        ++bucket_index;
+    }
+    auto size_of_equivalent_value_range = 1ul << (unit_magnitude + bucket_index);
+    auto next_non_equivalent_value = lowest_equivalent_value + size_of_equivalent_value_range;
+    return next_non_equivalent_value - 1;
+}
+
+std::int64_t HdrHistogram::get_lowest_equivalent_value(std::int64_t value) const noexcept
+{
+    auto bucket_index = get_bucket_index(value);
+    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
+    auto lowest_equivalent_value = get_value_from_sub_bucket(bucket_index, sub_bucket_index);
+    return lowest_equivalent_value;
+}
+
+std::int64_t HdrHistogram::get_value_from_sub_bucket(std::int64_t bucket_index,
+                                                     std::int64_t sub_bucket_index) const noexcept
+{
+    return sub_bucket_index << (bucket_index + unit_magnitude);
+}
+
+std::int64_t HdrHistogram::get_count_at_index(std::int64_t index) const noexcept
+{
+    // some decoded (read-only) histograms may have truncated
+    // counts arrays, we return zero for any index that is passed the array
+    //         if (index >= encoder.payload.counts_len){
+    //             return 0;
+    //         }
+    return counts_.at(index);
+}
+
+std::int64_t HdrHistogram::get_target_count_at_percentile(double percentile) const noexcept
+{
+    const auto requested_percentile = std::min(percentile, 100.0);
+    const int count_at_percentile = (requested_percentile * total_count_ / 100) + 0.5;
+    return std::max(count_at_percentile, 1);
+}
+
+std::int64_t HdrHistogram::counts_index_for(std::int64_t value) const noexcept
+{
+    auto bucket_index = get_bucket_index(value);
+    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
+    return counts_index(bucket_index, sub_bucket_index);
+}
+
+std::int64_t HdrHistogram::get_bucket_index(std::int64_t value) const noexcept
+{
+    // Smallest power of 2 containing value
+    auto pow2ceiling = 64 - __builtin_clzll(value | sub_bucket_mask);
+    return pow2ceiling - unit_magnitude - (sub_bucket_half_count_magnitude + 1);
+}
+
+std::int64_t HdrHistogram::get_sub_bucket_index(std::int64_t value, std::int64_t bucket_index) const
+    noexcept
+{
+    return value >> (bucket_index + unit_magnitude);
+}
+
+std::int64_t HdrHistogram::get_value_from_index(std::int64_t index) const noexcept
+{
+    int bucket_index = (index >> sub_bucket_half_count_magnitude) - 1;
+    auto sub_bucket_index = (index & (sub_bucket_half_count - 1)) + sub_bucket_half_count;
+    if (bucket_index < 0) {
+        sub_bucket_index -= sub_bucket_half_count;
+        bucket_index = 0;
+    }
+    return get_value_from_sub_bucket(bucket_index, sub_bucket_index);
+}
+
+std::int64_t HdrHistogram::counts_index(int bucket_index, int sub_bucket_index) const noexcept
+{
+    // Calculate the index for the first entry in the bucket:
+    // (The following is the equivalent of ((bucket_index + 1) * subBucketHalfCount) ):
+    auto bucket_base_index = (bucket_index + 1) << sub_bucket_half_count_magnitude;
+    // Calculate the offset in the bucket:
+    auto offset_in_bucket = sub_bucket_index - sub_bucket_half_count;
+    // The following is the equivalent of
+    //  ((sub_bucket_index  - subBucketHalfCount) + bucketBaseIndex
+    return bucket_base_index + offset_in_bucket;
+}
+
+std::int64_t HdrHistogram::hdr_size_of_equiv_value_range(std::int64_t value) const noexcept
+{
+    auto bucket_index = get_bucket_index(value);
+    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
+    if (sub_bucket_index >= sub_bucket_count) {
+        ++bucket_index;
+    }
+    return 1 << (unit_magnitude + bucket_index);
+}
+
+std::int64_t HdrHistogram::hdr_median_equiv_value(std::int64_t value) const noexcept
+{
+    return get_lowest_equivalent_value(value) + (hdr_size_of_equiv_value_range(value) >> 1);
+}
+
+std::ostream& operator<<(std::ostream& out, const HdrHistogram& hist)
+{
+    // TODO: Move to make_iterator functor
+    const double output_value_unit_scaling_ratio = 1000.0;
+    out << "       Value     Percentile TotalCount 1/(1-Percentile)\n\n";
+    for (const auto& iter_value : hist) {
+        const auto value = iter_value.value_iterated_to / output_value_unit_scaling_ratio;
+        const auto percentile = iter_value.percentile_level_iterated_to / 100;
+        const auto total_count = iter_value.total_count_to_this_value;
+
+        // clang-format off
+        out << std::setw(12) << std::defaultfloat << std::setprecision(12) << value
+            << std::setw(15) << std::fixed << std::setprecision(12) << percentile
+            << std::setw(11) << std::defaultfloat << total_count;
+        // clang-format on
+
+        if (iter_value.percentile_level_iterated_to != 100) {
+            double other = 1.0 / (1.0 - iter_value.percentile_level_iterated_to / 100.0);
+            out << std::setw(17) << std::fixed << std::setprecision(2) << other;
+        }
+        out << '\n';
+    }
+
+    const double mean = hist.mean() / output_value_unit_scaling_ratio;
+    const double stddev = hist.stddev();
+    const double max = hist.max() / output_value_unit_scaling_ratio;
+    const double total = hist.get_total_count();
+
+    // clang-format off
+    return out <<
+        "#[Mean    = " << std::setw(14) << std::setprecision(14) << mean << ", StdDeviation   = " << std::setprecision(13) << stddev << "]\n"
+        "#[Max     = " << std::setw(14) << std::setprecision(14) << max << ", TotalCount     = " << total << "]\n"
+        "#[Buckets = " << std::setw(14) << hist.bucket_count << ", SubBuckets     = " << hist.sub_bucket_count << "]\n";
+    // clang-format on
+}
+
+} // namespace hdr
+} // namespace toolbox

--- a/toolbox/hdr/HdrHistogram.hpp
+++ b/toolbox/hdr/HdrHistogram.hpp
@@ -1,0 +1,107 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef TOOLBOX_HDR_HISTOGRAM
+#define TOOLBOX_HDR_HISTOGRAM
+
+#include "HdrHistogramIterator.hpp"
+
+#include <toolbox/Config.h>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace toolbox {
+
+inline namespace hdr {
+
+class TOOLBOX_API HdrHistogram {
+
+  public:
+    HdrHistogram(std::int64_t lowest_value, std::int64_t highest_value,
+                 std::int64_t significant_figures);
+
+    PercentileIterator begin() const;
+    PercentileIterator end() const;
+
+    friend std::ostream& operator<<(std::ostream& out, const HdrHistogram& hist);
+    bool record(std::int64_t value, int count = 1);
+
+    std::int64_t percentile(double percentile) const noexcept;
+
+    /// Check whether two values are equivalent (meaning they
+    /// are in the same bucket/range)
+    /// Returns:
+    ///    true if the two values are equivalentv
+    std::int64_t values_are_equivalent(std::int64_t lhs, std::int64_t rhs);
+
+    std::int64_t max() const noexcept;
+    std::int64_t min() const noexcept;
+    double mean() const noexcept;
+    double stddev() const noexcept;
+
+    std::int64_t get_count_at_value(std::int64_t value) const noexcept;
+    std::int64_t get_total_count() const noexcept;
+
+    std::int64_t get_highest_equivalent_value(std::int64_t value) const noexcept;
+
+    const std::int64_t unit_magnitude;
+    const std::int64_t sub_bucket_half_count_magnitude;
+    const std::int64_t sub_bucket_count;
+    const std::int64_t sub_bucket_half_count;
+    const std::int64_t sub_bucket_mask;
+    const std::int64_t bucket_count;
+    const std::int64_t counts_len;
+
+  private:
+    friend class AbstractHdrIterator;
+    friend class RecordedIterator;
+    friend class PercentileIterator;
+    friend class AllValuesIterator;
+
+    std::int64_t get_lowest_equivalent_value(std::int64_t value) const noexcept;
+    std::int64_t get_value_from_sub_bucket(std::int64_t bucket_index,
+                                           std::int64_t sub_bucket_index) const noexcept;
+    std::int64_t get_count_at_index(std::int64_t index) const noexcept;
+    std::int64_t get_target_count_at_percentile(double percentile) const noexcept;
+    std::int64_t counts_index_for(std::int64_t value) const noexcept;
+
+    std::int64_t get_bucket_index(std::int64_t value) const noexcept;
+    std::int64_t get_sub_bucket_index(std::int64_t value, std::int64_t bucket_index) const noexcept;
+
+    std::int64_t get_value_from_index(std::int64_t index) const noexcept;
+    std::int64_t counts_index(int bucket_index, int sub_bucket_index) const noexcept;
+
+    std::int64_t hdr_size_of_equiv_value_range(std::int64_t value) const noexcept;
+    std::int64_t hdr_median_equiv_value(std::int64_t value) const noexcept;
+
+    std::int64_t counts_index_;
+
+    std::int64_t min_value_{std::numeric_limits<std::int64_t>::max()};
+    std::int64_t max_value_{0};
+
+    std::vector<std::int64_t> counts_;
+    std::int64_t total_count_{0};
+
+    double int_to_double_conversion_ratio_{1.0};
+};
+
+TOOLBOX_API std::ostream& operator<<(std::ostream& out, const HdrHistogram& hist);
+
+} // namespace hdr
+} // namespace toolbox
+#endif // TOOLBOX_HDR_HISTOGRAM

--- a/toolbox/hdr/HdrHistogram.ut.cpp
+++ b/toolbox/hdr/HdrHistogram.ut.cpp
@@ -1,0 +1,90 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "HdrHistogram.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace toolbox;
+
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_SUITE(HdrHistogramSuite)
+
+constexpr auto Lowest = 1;
+constexpr std::int64_t Highest = 3600ull * 1000 * 1000;
+constexpr auto Significant = 3;
+constexpr auto TestValueLevel = 4;
+constexpr auto Interval = 10000;
+constexpr auto Bitness = 64;
+
+BOOST_AUTO_TEST_CASE(HdrHistogramBasicCase)
+{
+    HdrHistogram hist{Lowest, Highest, Significant};
+    const auto expected_bucket_count = Bitness == 64 ? 22 : 21;
+    const auto expected_counts_len = Bitness == 64 ? 23552 : 22528;
+
+    BOOST_TEST(hist.bucket_count == expected_bucket_count);
+    BOOST_TEST(hist.sub_bucket_count == 2048);
+    BOOST_TEST(hist.counts_len == expected_counts_len);
+    BOOST_TEST(hist.unit_magnitude == 0);
+    BOOST_TEST(hist.sub_bucket_half_count_magnitude == 10);
+}
+
+BOOST_AUTO_TEST_CASE(HdrHistogramEmptyCase)
+{
+    HdrHistogram hist{1, 100000000, 1};
+
+    BOOST_TEST(hist.min() == 0);
+    BOOST_TEST(hist.max() == 0);
+    BOOST_TEST(hist.mean() == 0);
+    BOOST_TEST(hist.stddev() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(HdrHistogramRecordValueCase)
+{
+    HdrHistogram hist{Lowest, Highest, Significant};
+    hist.record(TestValueLevel);
+    BOOST_TEST(hist.get_count_at_value(TestValueLevel) == 1);
+    BOOST_TEST(hist.get_total_count() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(HdrHistogramRecordEquivalentValueCase)
+{
+    HdrHistogram histogram{Lowest, Highest, Significant};
+    BOOST_TEST(8183 * 1024 + 1023 == histogram.get_highest_equivalent_value(8180 * 1024));
+    BOOST_TEST(8191 * 1024 + 1023 == histogram.get_highest_equivalent_value(8191 * 1024));
+    BOOST_TEST(8199 * 1024 + 1023 == histogram.get_highest_equivalent_value(8193 * 1024));
+    BOOST_TEST(9999 * 1024 + 1023 == histogram.get_highest_equivalent_value(9995 * 1024));
+    BOOST_TEST(10007 * 1024 + 1023 == histogram.get_highest_equivalent_value(10007 * 1024));
+    BOOST_TEST(10015 * 1024 + 1023 == histogram.get_highest_equivalent_value(10008 * 1024));
+}
+
+BOOST_AUTO_TEST_CASE(HdrHistogramLargeNumbersCase)
+{
+    HdrHistogram hist{20000000, 100000000, 5};
+    hist.record(100000000);
+    hist.record(20000000);
+    hist.record(30000000);
+
+    BOOST_TEST(hist.values_are_equivalent(hist.percentile(50.0), 20000000));
+    BOOST_TEST(hist.values_are_equivalent(hist.percentile(83.33), 30000000));
+    BOOST_TEST(hist.values_are_equivalent(hist.percentile(83.34), 100000000));
+    BOOST_TEST(hist.values_are_equivalent(hist.percentile(99.0), 100000000));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/hdr/HdrHistogramIterator.cpp
+++ b/toolbox/hdr/HdrHistogramIterator.cpp
@@ -1,0 +1,264 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "HdrHistogramIterator.hpp"
+#include "HdrHistogram.hpp"
+
+namespace toolbox {
+
+inline namespace hdr {
+
+using RecordedIteratorAdapter = IteratorAdapter<RecordedIterator>;
+
+// Empty histogram for past the end iterator
+static const HdrHistogram empty_hist{1, 1, 1};
+
+AllValuesIterator::AllValuesIterator() = default;
+
+AllValuesIterator::AllValuesIterator(const HdrHistogram& histogram)
+: AbstractHdrIterator{histogram}
+{
+}
+
+bool AllValuesIterator::reached_iteration_level() const
+{
+    return visited_index_ != this->current_index_;
+}
+
+void AllValuesIterator::increment_iteration_level()
+{
+    visited_index_ = this->current_index_;
+}
+
+bool AllValuesIterator::has_next()
+{
+    bool next = this->current_index_ < this->histogram_.counts_len - 1;
+    if (!next) {
+        this->end_ = true;
+    }
+    return next;
+}
+
+bool RecordedIterator::reached_iteration_level() const
+{
+    const auto current_count = this->histogram_.get_count_at_index(current_index_);
+    return current_count and (visited_index_ != current_index_);
+}
+
+RecordedIterator::RecordedIterator() = default;
+
+RecordedIterator::RecordedIterator(const HdrHistogram& histogram)
+: AllValuesIterator{histogram}
+{
+}
+
+bool operator==(const RecordedIterator& lhs, const RecordedIterator& rhs)
+{
+    return lhs.end_ == rhs.end_;
+}
+
+bool operator!=(const RecordedIterator& lhs, const RecordedIterator& rhs)
+{
+    return !(lhs == rhs);
+}
+
+/// End iterators
+
+HdrIterationValue::HdrIterationValue(const AbstractHdrIterator& iterator)
+: iterator_{iterator}
+{
+}
+
+void HdrIterationValue::set(std::int64_t value) noexcept
+{
+    value_iterated_to = value;
+    value_iterated_from = iterator_.prev_value_iterated_to_;
+    count_at_value_iterated_to = iterator_.count_at_this_value_;
+    count_added_in_this_iter_step
+        = iterator_.total_count_to_current_index_ - iterator_.total_count_to_prev_index_;
+    total_count_to_this_value = iterator_.total_count_to_current_index_;
+    total_value_to_this_value = iterator_.value_to_index_;
+    percentile = (100.0 * iterator_.total_count_to_current_index_) / iterator_.total_count_;
+    percentile_level_iterated_to = iterator_.get_percentile_iterated_to();
+    int_to_double_conversion_ratio = iterator_.int_to_double_conversion_ratio_;
+}
+
+AbstractHdrIterator::AbstractHdrIterator()
+: histogram_{empty_hist}
+, current_iteration_value_{*this}
+, end_{true}
+{
+}
+
+AbstractHdrIterator::AbstractHdrIterator(const HdrHistogram& histogram)
+: histogram_{histogram} //         , total_count_to_current_index_{total_count_to_current_index}
+, value_at_next_index_{1ll << histogram.unit_magnitude}
+, current_iteration_value_{*this}
+, total_count_{histogram.total_count_}
+, int_to_double_conversion_ratio_{histogram.int_to_double_conversion_ratio_}
+{
+}
+
+AbstractHdrIterator::~AbstractHdrIterator() = default;
+
+AbstractHdrIterator& AbstractHdrIterator::operator++()
+{
+    while (has_next()) {
+        count_at_this_value_ = histogram_.get_count_at_index(current_index_);
+        if (fresh_sub_bucket_) {
+            total_count_to_current_index_ += count_at_this_value_;
+            value_to_index_ += count_at_this_value_ * get_value_iterated_to();
+            fresh_sub_bucket_ = false;
+        }
+        if (reached_iteration_level()) {
+            auto value_iterated_to = get_value_iterated_to();
+            current_iteration_value_.set(value_iterated_to);
+
+            prev_value_iterated_to_ = value_iterated_to;
+            total_count_to_prev_index_ = total_count_to_current_index_;
+
+            increment_iteration_level();
+
+            return *this;
+        }
+
+        increment_sub_bucket();
+    }
+    return *this;
+}
+
+void AbstractHdrIterator::increment_sub_bucket()
+{
+    fresh_sub_bucket_ = true;
+    ++current_index_;
+    value_at_index_ = histogram_.get_value_from_index(current_index_);
+    value_at_next_index_ = histogram_.get_value_from_index(current_index_ + 1);
+}
+
+bool AbstractHdrIterator::has_next()
+{
+    return total_count_to_current_index_ < total_count_;
+}
+
+std::int64_t AbstractHdrIterator::get_count_at_this_value() const noexcept
+{
+    return count_at_this_value_;
+}
+
+double AbstractHdrIterator::get_percentile_iterated_to() const noexcept
+{
+    return (100.0 * total_count_to_current_index_) / total_count_;
+}
+
+double AbstractHdrIterator::get_percentile_iterated_from() const noexcept
+{
+    return (100.0 * total_count_to_prev_index_) / total_count_;
+}
+
+std::int64_t AbstractHdrIterator::get_value_iterated_to() const
+{
+    return histogram_.get_highest_equivalent_value(value_at_index_);
+}
+
+PercentileIterator::PercentileIterator() = default;
+
+PercentileIterator::PercentileIterator(const HdrHistogram& histogram,
+                                       double percentile_ticks_per_half_distance)
+: AbstractHdrIterator{histogram}
+, percentile_ticks_per_half_distance_{percentile_ticks_per_half_distance}
+{
+}
+
+const HdrIterationValue& AbstractHdrIterator::operator*() const noexcept
+{
+    return this->current_iteration_value_;
+}
+const HdrIterationValue* AbstractHdrIterator::operator->() const noexcept
+{
+    return &this->current_iteration_value_;
+}
+
+bool PercentileIterator::has_next()
+{
+    if (AbstractHdrIterator::has_next()) {
+        return true;
+    }
+
+    // We want one additional last step to 100%
+    if (!reached_last_recorded_value_ && this->total_count_) {
+        percentile_to_iterate_to_ = 100.0;
+        reached_last_recorded_value_ = true;
+        return true;
+    }
+
+    this->end_ = true;
+    return false;
+}
+
+void PercentileIterator::increment_iteration_level()
+{
+    this->percentile_to_iterate_from_ = this->percentile_to_iterate_to_;
+    auto percentile_gap{100.0 - this->percentile_to_iterate_to_};
+    if (percentile_gap) {
+        auto half_distance = std::pow(2, (std::log(100 / percentile_gap) / std::log(2)) + 1);
+        auto percentile_reporting_ticks = percentile_ticks_per_half_distance_ * half_distance;
+        this->percentile_to_iterate_to_ += 100.0 / percentile_reporting_ticks;
+    }
+}
+
+bool PercentileIterator::reached_iteration_level() const
+{
+    if (this->count_at_this_value_ == 0) {
+        return false;
+    }
+    auto current_percentile = (100.0 * this->total_count_to_current_index_) / this->total_count_;
+    return current_percentile >= this->percentile_to_iterate_to_;
+}
+
+double PercentileIterator::get_percentile_iterated_to() const noexcept
+{
+    return this->percentile_to_iterate_to_;
+}
+
+double PercentileIterator::get_percentile_iterated_from() const noexcept
+{
+    return this->percentile_to_iterate_from_;
+}
+
+PercentileIterator HdrHistogram::begin() const
+{
+    PercentileIterator p{*this};
+    // TODO port leftover, having to inc manually
+    ++p;
+    return p;
+}
+
+PercentileIterator HdrHistogram::end() const
+{
+    return {};
+}
+
+bool operator==(const PercentileIterator& lhs, const PercentileIterator& rhs)
+{
+    return lhs.end_ == rhs.end_;
+}
+
+bool operator!=(const PercentileIterator& lhs, const PercentileIterator& rhs)
+{
+    return !(lhs == rhs);
+}
+
+} // namespace hdr
+} // namespace toolbox

--- a/toolbox/hdr/HdrHistogramIterator.hpp
+++ b/toolbox/hdr/HdrHistogramIterator.hpp
@@ -1,0 +1,177 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef TOOLBOX_HDR_HISTOGRAM_ITERATOR
+#define TOOLBOX_HDR_HISTOGRAM_ITERATOR
+
+#include <toolbox/Config.h>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace toolbox {
+
+inline namespace hdr {
+
+class HdrHistogram;
+class AbstractHdrIterator;
+
+class HdrIterationValue {
+  public:
+    std::int64_t value_iterated_to{0};
+    std::int64_t value_iterated_from{0};
+    std::int64_t count_at_value_iterated_to{0};
+    std::int64_t count_added_in_this_iter_step{0};
+    std::int64_t total_count_to_this_value{0};
+    std::int64_t total_value_to_this_value{0};
+    double percentile{0.0};
+    double percentile_level_iterated_to{0.0};
+    double int_to_double_conversion_ratio{1.0};
+
+    HdrIterationValue(const AbstractHdrIterator& iterator);
+
+    void set(std::int64_t value) noexcept;
+
+  private:
+    const AbstractHdrIterator& iterator_;
+};
+
+class AbstractHdrIterator {
+  public:
+    /// Past the end iterator
+    AbstractHdrIterator();
+
+    explicit AbstractHdrIterator(const HdrHistogram& histogram);
+
+    virtual ~AbstractHdrIterator();
+    virtual bool reached_iteration_level() const = 0;
+    virtual void increment_iteration_level() = 0;
+
+    AbstractHdrIterator& operator++();
+
+    void increment_sub_bucket();
+
+    const HdrIterationValue& operator*() const noexcept;
+    const HdrIterationValue* operator->() const noexcept;
+
+    virtual bool has_next();
+    virtual double get_percentile_iterated_to() const noexcept;
+    virtual double get_percentile_iterated_from() const noexcept;
+
+    std::int64_t get_value_iterated_to() const;
+    std::int64_t get_count_at_this_value() const noexcept;
+
+  protected:
+    friend class HdrIterationValue;
+
+    const HdrHistogram& histogram_;
+    std::int64_t current_index_{0};
+    std::int64_t count_at_this_value_{0};
+    std::int64_t total_count_to_current_index_{0};
+    std::int64_t total_count_to_prev_index_{0};
+    std::int64_t prev_value_iterated_to_{0};
+    std::int64_t value_at_index_{0};
+    std::int64_t value_to_index_{0};
+    std::int64_t value_at_next_index_{0};
+    HdrIterationValue current_iteration_value_;
+    std::int64_t total_count_;
+    bool fresh_sub_bucket_{true};
+    bool end_{false};
+    double int_to_double_conversion_ratio_{1.0};
+};
+
+class AllValuesIterator : public AbstractHdrIterator {
+  public:
+    // Past the end iterator
+    AllValuesIterator();
+
+    explicit AllValuesIterator(const HdrHistogram& histogram);
+
+    bool reached_iteration_level() const override;
+    void increment_iteration_level() override;
+    bool has_next() override;
+
+  protected:
+    std::int64_t visited_index_{-1};
+};
+
+/// Provide a means of iterating through all recorded histogram values
+/// using the finest granularity steps supported by the underlying representation.
+/// The iteration steps through all non-zero recorded value counts,
+/// and terminates when all recorded histogram values are exhausted.
+class RecordedIterator : public AllValuesIterator {
+  public:
+    bool reached_iteration_level() const override;
+
+    /// Past the end iterator
+    RecordedIterator();
+    explicit RecordedIterator(const HdrHistogram& histogram);
+    friend bool operator==(const RecordedIterator& lhs, const RecordedIterator& rhs);
+    friend bool operator!=(const RecordedIterator& lhs, const RecordedIterator& rhs);
+};
+
+template <class IteratorType>
+class IteratorAdapter {
+  public:
+    explicit IteratorAdapter(const HdrHistogram& histogram)
+    : histogram_{histogram}
+    {
+    }
+
+    IteratorType begin() const
+    {
+        auto it = IteratorType{histogram_};
+        ++it;
+        return it;
+    }
+    IteratorType end() const { return {}; }
+
+  private:
+    const HdrHistogram& histogram_;
+};
+
+class PercentileIterator : public AbstractHdrIterator {
+  public:
+    /// Past the end iterator
+    PercentileIterator();
+
+    explicit PercentileIterator(const HdrHistogram& histogram,
+                                double percentile_ticks_per_half_distance = 5);
+
+    friend bool operator==(const PercentileIterator& lhs, const PercentileIterator& rhs);
+
+    friend bool operator!=(const PercentileIterator& lhs, const PercentileIterator& rhs);
+
+    bool has_next() override;
+
+    void increment_iteration_level() override;
+
+    bool reached_iteration_level() const override;
+
+    double get_percentile_iterated_to() const noexcept override;
+    double get_percentile_iterated_from() const noexcept override;
+
+  private:
+    double percentile_ticks_per_half_distance_;
+    bool reached_last_recorded_value_{false};
+    double percentile_to_iterate_to_{0.0};
+    double percentile_to_iterate_from_{0.0};
+};
+
+} // namespace hdr
+} // namespace toolbox
+#endif // TOOLBOX_HDR_HISTOGRAM_ITERATOR

--- a/toolbox/util/Utility.cpp
+++ b/toolbox/util/Utility.cpp
@@ -37,24 +37,7 @@ int dec_digits(int64_t i) noexcept
 
 int hex_digits(int64_t i) noexcept
 {
-    // clang-format off
-    return i & 0xffffffff00000000
-        ? i & 0xffff000000000000
-            ? i & 0xff00000000000000
-                ? i & 0xf000000000000000 ? 16:15
-                : i & 0x00f0000000000000 ? 14:13
-            : i & 0xff0000000000
-                ? i & 0xf00000000000 ? 12:11
-                : i & 0x00f000000000 ? 10:9
-        : i & 0xffff0000
-            ? i & 0xff000000
-                ? i & 0xf0000000 ? 8:7
-                : i & 0x00f00000 ? 6:5
-            : i & 0xff00
-                ? i & 0xf000 ? 4:3
-                : i & 0x00f0 ? 2:1
-        ;
-    // clang-format on
+    return 1 + ((63 - __builtin_clzl(i | 1)) / 4);
 }
 
 bool stob(string_view sv, bool dfl) noexcept


### PR DESCRIPTION
Integration with bencharking utils via -o hdr and -o stat options

While functional from missing things include:
  * Correct iterator semantics
  * Load / Dump capabilities
  * Support for different sizes (currently using uint64_t)

Close #39