### PR TITLE
Remove epoll_create size hint

### DIFF
--- a/toolbox/io/Epoll.hpp
+++ b/toolbox/io/Epoll.hpp
@@ -25,7 +25,8 @@
 namespace toolbox {
 namespace os {
 
-/// Open an epoll file descriptor
+/// Open a new epoll instance. The size argument is ignored in kernels >= 2.6.8, but must be greater
+/// than zero.
 inline FileHandle epoll_create(int size, std::error_code& ec) noexcept
 {
     const auto ret = ::epoll_create(size);
@@ -35,12 +36,33 @@ inline FileHandle epoll_create(int size, std::error_code& ec) noexcept
     return ret;
 }
 
-/// Open an epoll file descriptor
+/// Open a new epoll instance. The size argument is ignored in kernels >= 2.6.8, but must be greater
+/// than zero.
 inline FileHandle epoll_create(int size)
 {
     const auto fd = ::epoll_create(size);
     if (fd < 0) {
         throw std::system_error{make_sys_error(errno), "epoll_create"};
+    }
+    return fd;
+}
+
+/// Open a new epoll instance. If flags is zero, then epoll_create1() is the same as epoll_create().
+inline FileHandle epoll_create1(int flags, std::error_code& ec) noexcept
+{
+    const auto ret = ::epoll_create1(flags);
+    if (ret < 0) {
+        ec = make_sys_error(errno);
+    }
+    return ret;
+}
+
+/// Open a new epoll instance. If flags is zero, then epoll_create1() is the same as epoll_create().
+inline FileHandle epoll_create1(int flags)
+{
+    const auto fd = ::epoll_create1(flags);
+    if (fd < 0) {
+        throw std::system_error{make_sys_error(errno), "epoll_create1"};
     }
     return fd;
 }

--- a/toolbox/io/EpollReactor.cpp
+++ b/toolbox/io/EpollReactor.cpp
@@ -29,7 +29,6 @@ constexpr size_t MaxEvents{16};
 } // namespace
 
 EpollReactor::EpollReactor(std::size_t size_hint)
-: mux_{size_hint}
 {
     const auto notify = notify_.fd();
     data_.resize(max<size_t>(notify + 1, size_hint));

--- a/toolbox/io/EpollReactor.hpp
+++ b/toolbox/io/EpollReactor.hpp
@@ -28,7 +28,7 @@ class TOOLBOX_API EpollReactor : public Reactor {
   public:
     using Event = typename EpollMuxer::Event;
 
-    explicit EpollReactor(std::size_t size_hint = 1024);
+    explicit EpollReactor(std::size_t size_hint = 0);
     ~EpollReactor() final;
 
     // Copy.

--- a/toolbox/io/Muxer.hpp
+++ b/toolbox/io/Muxer.hpp
@@ -64,8 +64,8 @@ class EpollMuxer {
         return n;
     }
 
-    explicit EpollMuxer(std::size_t size_hint)
-    : mux_{os::epoll_create(size_hint)}
+    explicit EpollMuxer(int flags = 0)
+    : mux_{os::epoll_create1(flags)}
     , tfd_{TFD_NONBLOCK}
     {
         subscribe(tfd_.fd(), 0, EventIn);

--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -48,8 +48,8 @@ TOOLBOX_API Logger get_logger() noexcept;
 TOOLBOX_API Logger set_logger(Logger logger) noexcept;
 
 /// Unconditionally write log message to the logger. Specifically, this function does not check that
-/// level is allowed by the current log level; users are expected to call is_log_level first, before
-/// formatting the log message.
+/// level is allowed by the current log level; users are expected to call is_log_level() first,
+/// before formatting the log message.
 TOOLBOX_API void write_log(int level, std::string_view msg) noexcept;
 
 /// Null logger. This logger does nothing and is effectively /dev/null.


### PR DESCRIPTION
In the initial `epoll_create()` implementation, the size argument informed the kernel of the number of file descriptors that the caller expected to add to the epoll instance. Modern kernels no longer require this hint.

Closes #44