### PR TITLE
Align HdrHistogram to C version

### DIFF
--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories(SYSTEM
 set(lib_SOURCES
   hdr/Histogram.cpp
   hdr/Iterator.cpp
+  hdr/Utility.cpp
   http/App.cpp
   http/Conn.cpp
   http/Error.cpp
@@ -199,9 +200,10 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU AND ${CMAKE_BUILD_TYPE} MATCHES COVERAGE
   endif()
 endif()
 
-
 set(test_SOURCES
   hdr/Histogram.ut.cpp
+  hdr/Iterator.ut.cpp
+  hdr/Utility.ut.cpp
   http/Parser.ut.cpp
   http/Types.ut.cpp
   http/Url.ut.cpp

--- a/toolbox/bm/Range.cpp
+++ b/toolbox/bm/Range.cpp
@@ -37,7 +37,7 @@ BenchmarkRange::~BenchmarkRange()
     const auto elapsed = chrono::duration_cast<chrono::nanoseconds>(end - start_);
     const auto count = last_ - first_;
     // Record average.
-    hist_.record(elapsed.count() / count, count);
+    hist_.record_values(elapsed.count() / count, count);
 }
 
 } // namespace toolbox::bm

--- a/toolbox/bm/Record.cpp
+++ b/toolbox/bm/Record.cpp
@@ -35,7 +35,7 @@ BenchmarkRecord::~BenchmarkRecord()
     const auto end = chrono::high_resolution_clock::now();
     const auto elapsed = chrono::duration_cast<chrono::nanoseconds>(end - start_);
     // Record average.
-    hist_.record(elapsed.count() / count_, count_);
+    hist_.record_values(elapsed.count() / count_, count_);
 }
 
 } // namespace toolbox::bm

--- a/toolbox/bm/Suite.cpp
+++ b/toolbox/bm/Suite.cpp
@@ -15,6 +15,12 @@
 
 #include "Suite.hpp"
 
+#include <toolbox/hdr/Utility.hpp>
+
+#include <boost/io/ios_state.hpp>
+
+#include <iomanip>
+
 namespace toolbox::bm {
 using namespace std;
 
@@ -22,33 +28,37 @@ BenchmarkSuite::BenchmarkSuite(std::ostream& os, double value_scale)
 : os_{os}
 , value_scale_{value_scale}
 {
+    boost::io::ios_all_saver all_saver{os};
+
     // clang-format off
-    os_ << left << setw(45) << "NAME"
-        << right << setw(15) << "COUNT"
-        << right << setw(10) << "MIN"
-        << right << setw(10) << "%50"
-        << right << setw(10) << "%95"
-        << right << setw(10) << "%99"
-        << right << setw(10) << "%99.9"
-        << right << setw(10) << "%99.99"
-        << endl;
+    os << left << setw(45) << "NAME"
+       << right << setw(15) << "COUNT"
+       << right << setw(10) << "MIN"
+       << right << setw(10) << "%50"
+       << right << setw(10) << "%95"
+       << right << setw(10) << "%99"
+       << right << setw(10) << "%99.9"
+       << right << setw(10) << "%99.99"
+       << endl;
     // clang-format on
 
     // Separator.
-    os_ << setw(120) << setfill('-') << '-' << setfill(' ') << endl;
+    os << setw(120) << setfill('-') << '-' << setfill(' ') << endl;
 }
 
-void BenchmarkSuite::report(const char* name, HdrHistogram& hist)
+void BenchmarkSuite::report(const char* name, HdrHistogram& h)
 {
+    boost::io::ios_all_saver all_saver{os_};
+
     // clang-format off
     os_ << left << setw(45) << name
-        << right << setw(15) << hist.get_total_count()
-        << right << setw(10) << hist.min() / value_scale_
-        << right << setw(10) << hist.percentile(50) / value_scale_
-        << right << setw(10) << hist.percentile(95) / value_scale_
-        << right << setw(10) << hist.percentile(99) / value_scale_
-        << right << setw(10) << hist.percentile(99.9) / value_scale_
-        << right << setw(10) << hist.percentile(99.99) / value_scale_
+        << right << setw(15) << h.total_count()
+        << right << setw(10) << h.min() / value_scale_
+        << right << setw(10) << value_at_percentile(h, 50) / value_scale_
+        << right << setw(10) << value_at_percentile(h, 95) / value_scale_
+        << right << setw(10) << value_at_percentile(h, 99) / value_scale_
+        << right << setw(10) << value_at_percentile(h, 99.9) / value_scale_
+        << right << setw(10) << value_at_percentile(h, 99.99) / value_scale_
         << endl;
     // clang-format on
 }

--- a/toolbox/hdr.hpp
+++ b/toolbox/hdr.hpp
@@ -18,5 +18,6 @@
 
 #include "hdr/Histogram.hpp"
 #include "hdr/Iterator.hpp"
+#include "hdr/Utility.hpp"
 
 #endif // TOOLBOX_HDR_HPP

--- a/toolbox/hdr/Histogram.cpp
+++ b/toolbox/hdr/Histogram.cpp
@@ -15,16 +15,32 @@
 
 #include "Histogram.hpp"
 
+#include <cmath>
+#include <stdexcept>
+
 namespace toolbox {
 inline namespace hdr {
 using namespace std;
 namespace {
-int64_t get_bucket_count(int64_t value, int64_t subb_count, int64_t unit_mag) noexcept
+
+// Smallest power of 2 containing value.
+int32_t count_leading_zeros_64(int64_t value) noexcept
 {
-    auto smallest_untrackable_value = subb_count << unit_mag;
-    auto buckets_needed = 1;
+    return __builtin_clzll(value);
+}
+
+int32_t get_sub_bucket_index(int64_t value, int32_t bucket_index, int32_t unit_magnitude) noexcept
+{
+    return value >> (bucket_index + unit_magnitude);
+}
+
+int32_t buckets_needed_to_cover_value(int64_t value, int64_t sub_bucket_count,
+                                      int32_t unit_magnitude) noexcept
+{
+    int64_t smallest_untrackable_value{sub_bucket_count << unit_magnitude};
+    int32_t buckets_needed{1};
     while (smallest_untrackable_value <= value) {
-        if (smallest_untrackable_value > (numeric_limits<int64_t>::max() / 2)) {
+        if (smallest_untrackable_value > numeric_limits<int64_t>::max() / 2) {
             return buckets_needed + 1;
         }
         smallest_untrackable_value <<= 1;
@@ -33,155 +49,152 @@ int64_t get_bucket_count(int64_t value, int64_t subb_count, int64_t unit_mag) no
     return buckets_needed;
 }
 
-int64_t init_sub_bucket_half_count_magnitude(int64_t significant_figures)
+int64_t value_from_index(int32_t bucket_index, int32_t sub_bucket_index,
+                         int32_t unit_magnitude) noexcept
 {
-    double largest_value_single_unit_res = 2 * pow(10, significant_figures);
-    auto subb_count_mag = static_cast<int64_t>(ceil(log(largest_value_single_unit_res) / log(2)));
-    return subb_count_mag > 1 ? subb_count_mag - 1 : 0;
+    return int64_t{sub_bucket_index} << (bucket_index + unit_magnitude);
 }
+
+int32_t get_sub_bucket_half_count_magnitude(int64_t significant_figures) noexcept
+{
+    const double largest_value_with_single_unit_resolution{pow(10, significant_figures) * 2.0};
+    const int32_t sub_bucket_count_magnitude
+        = ceil(log(largest_value_with_single_unit_resolution) / log(2));
+    return sub_bucket_count_magnitude > 1 ? sub_bucket_count_magnitude - 1 : 0;
+}
+
 } // namespace
 
-HdrHistogram::HdrHistogram(int64_t lowest_value, int64_t highest_value, int64_t significant_figures)
-: unit_magnitude{static_cast<int64_t>(floor(log(lowest_value) / log(2)))}
-, sub_bucket_half_count_magnitude{init_sub_bucket_half_count_magnitude(significant_figures)}
+HdrBucketConfig::HdrBucketConfig(int64_t lowest_trackable_value, int64_t highest_trackable_value,
+                                 int32_t significant_figures)
+: lowest_trackable_value{lowest_trackable_value}
+, highest_trackable_value{highest_trackable_value}
+, significant_figures{significant_figures}
+, unit_magnitude(floor(log(lowest_trackable_value) / log(2)))
+, sub_bucket_half_count_magnitude{get_sub_bucket_half_count_magnitude(significant_figures)}
 , sub_bucket_count(pow(2, sub_bucket_half_count_magnitude + 1))
 , sub_bucket_half_count{sub_bucket_count / 2}
-, sub_bucket_mask{(sub_bucket_count - 1) << unit_magnitude}
-, bucket_count{get_bucket_count(highest_value, sub_bucket_count, unit_magnitude)}
+, sub_bucket_mask{int64_t{sub_bucket_count - 1} << unit_magnitude}
+, bucket_count{buckets_needed_to_cover_value(highest_trackable_value, sub_bucket_count,
+                                             unit_magnitude)}
 , counts_len{(bucket_count + 1) * (sub_bucket_count / 2)}
 {
-    if (highest_value < 1) {
-        throw runtime_error{"min value must be greater than zero"};
+    if (lowest_trackable_value < 1) {
+        throw invalid_argument{"min value must be greater than zero"};
     }
     if (significant_figures < 1 || significant_figures > 5) {
-        throw runtime_error{"significant figures must be between 1 and 5"};
+        throw invalid_argument{"significant figures must be between 1 and 5"};
     }
-    counts_.resize(counts_len);
-}
-
-PercentileIterator HdrHistogram::begin() const
-{
-    PercentileIterator p{*this};
-    // TODO port leftover, having to inc manually
-    ++p;
-    return p;
-}
-
-PercentileIterator HdrHistogram::end() const
-{
-    return {};
-}
-
-int64_t HdrHistogram::percentile(double percentile) const
-{
-    auto count_at_percentile = get_target_count_at_percentile(percentile);
-    int64_t total = 0;
-    for (int64_t i = 0; i < counts_len; ++i) {
-        total += get_count_at_index(i);
-        if (total >= count_at_percentile) {
-            auto value_at_index = get_value_from_index(i);
-            return percentile ? get_highest_equivalent_value(value_at_index)
-                              : get_lowest_equivalent_value(value_at_index);
-        }
+    if (lowest_trackable_value * 2 > highest_trackable_value) {
+        throw invalid_argument{"highest trackable value too small"};
     }
-    return 0;
+    if (unit_magnitude + sub_bucket_half_count_magnitude > 61) {
+        throw invalid_argument{"invalid magnitude"};
+    }
 }
 
-int64_t HdrHistogram::values_are_equivalent(int64_t lhs, int64_t rhs) const noexcept
+HdrHistogram::HdrHistogram(const HdrBucketConfig& config)
+: lowest_trackable_value_{config.lowest_trackable_value}
+, highest_trackable_value_{config.highest_trackable_value}
+, significant_figures_{config.significant_figures}
+, unit_magnitude_{config.unit_magnitude}
+, sub_bucket_half_count_magnitude_{config.sub_bucket_half_count_magnitude}
+, sub_bucket_count_{config.sub_bucket_count}
+, sub_bucket_half_count_{config.sub_bucket_half_count}
+, sub_bucket_mask_{config.sub_bucket_mask}
+, bucket_count_{config.bucket_count}
+, normalizing_index_offset_{0}
+, min_value_{numeric_limits<int64_t>::max()}
+, max_value_{0}
+, total_count_{0}
 {
-    return get_lowest_equivalent_value(lhs) == get_lowest_equivalent_value(rhs);
+    counts_.resize(config.counts_len);
 }
 
-int64_t HdrHistogram::max() const noexcept
+HdrHistogram::HdrHistogram(int64_t lowest_trackable_value, int64_t highest_trackable_value,
+                           int significant_figures)
+: HdrHistogram{
+    HdrBucketConfig{lowest_trackable_value, highest_trackable_value, significant_figures}}
 {
-    return max_value_ ? get_highest_equivalent_value(max_value_) : 0;
 }
 
 int64_t HdrHistogram::min() const noexcept
 {
-    if (total_count_ == 0 || counts_[0] > 0) {
+    if (count_at_index(0) > 0) {
         return 0;
     }
-    if (numeric_limits<int64_t>::max() == min_value_) {
-        return min_value_;
-    }
-    return get_lowest_equivalent_value(min_value_);
+    return non_zero_min();
 }
 
-using RecordedIteratorAdapter = IteratorAdapter<RecordedIterator>;
-
-double HdrHistogram::mean() const noexcept
+int64_t HdrHistogram::max() const noexcept
 {
-    if (!total_count_) {
-        return 0.0;
+    if (max_value_ == 0) {
+        return 0;
     }
-    double total{0.0};
-    auto iter_adapter = RecordedIteratorAdapter(*this);
-    const auto& end = iter_adapter.end();
-    for (auto itr = iter_adapter.begin(); itr != end; ++itr) {
-        total += itr.get_count_at_this_value() * hdr_median_equiv_value(itr->value_iterated_to);
-    }
-    return total / total_count_;
+    return highest_equivalent_value(max_value_);
 }
 
-double HdrHistogram::stddev() const noexcept
+bool HdrHistogram::values_are_equivalent(int64_t a, int64_t b) const noexcept
 {
-    if (!total_count_) {
-        return 0.0;
+    return lowest_equivalent_value(a) == lowest_equivalent_value(b);
+}
+
+int64_t HdrHistogram::lowest_equivalent_value(int64_t value) const noexcept
+{
+    const int32_t bucket_index{get_bucket_index(value)};
+    const int32_t sub_bucket_index{get_sub_bucket_index(value, bucket_index, unit_magnitude_)};
+    return value_from_index(bucket_index, sub_bucket_index, unit_magnitude_);
+}
+
+int64_t HdrHistogram::highest_equivalent_value(int64_t value) const noexcept
+{
+    return next_non_equivalent_value(value) - 1;
+}
+
+int64_t HdrHistogram::count_at_value(int64_t value) const noexcept
+{
+    return counts_get_normalised(counts_index_for(value));
+}
+
+int64_t HdrHistogram::count_at_index(int32_t index) const noexcept
+{
+    return counts_get_normalised(index);
+}
+
+int64_t HdrHistogram::value_at_index(int32_t index) const noexcept
+{
+    int32_t bucket_index{(index >> sub_bucket_half_count_magnitude_) - 1};
+    int32_t sub_bucket_index{(index & (sub_bucket_half_count_ - 1)) + sub_bucket_half_count_};
+
+    if (bucket_index < 0) {
+        sub_bucket_index -= sub_bucket_half_count_;
+        bucket_index = 0;
     }
-    const auto mean_value = mean();
-    double geometric_dev_total{0.0};
-    for (const auto& item : RecordedIteratorAdapter(*this)) {
-        const auto dev = (hdr_median_equiv_value(item.value_iterated_to) * 1.0) - mean_value;
-        geometric_dev_total += (dev * dev) * item.count_added_in_this_iter_step;
-    }
-    return sqrt(geometric_dev_total / total_count_);
+    return value_from_index(bucket_index, sub_bucket_index, unit_magnitude_);
 }
 
-int64_t HdrHistogram::get_count_at_value(int64_t value) const noexcept
+int64_t HdrHistogram::size_of_equivalent_value_range(int64_t value) const noexcept
 {
-    auto counts_index = counts_index_for(value);
-    return counts_[counts_index];
+    const int32_t bucket_index{get_bucket_index(value)};
+    const int32_t sub_bucket_index{get_sub_bucket_index(value, bucket_index, unit_magnitude_)};
+    const int32_t adjusted_bucket{(sub_bucket_index >= sub_bucket_count_) ? (bucket_index + 1)
+                                                                          : bucket_index};
+    return int64_t{1} << (unit_magnitude_ + adjusted_bucket);
 }
 
-int64_t HdrHistogram::get_total_count() const noexcept
+int64_t HdrHistogram::next_non_equivalent_value(int64_t value) const noexcept
 {
-    return total_count_;
+    return lowest_equivalent_value(value) + size_of_equivalent_value_range(value);
 }
 
-int64_t HdrHistogram::get_highest_equivalent_value(int64_t value) const noexcept
+int64_t HdrHistogram::median_equivalent_value(int64_t value) const noexcept
 {
-    auto bucket_index = get_bucket_index(value);
-    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
-
-    auto lowest_equivalent_value = get_value_from_sub_bucket(bucket_index, sub_bucket_index);
-    if (sub_bucket_index >= sub_bucket_count) {
-        ++bucket_index;
-    }
-    auto size_of_equivalent_value_range = 1ul << (unit_magnitude + bucket_index);
-    auto next_non_equivalent_value = lowest_equivalent_value + size_of_equivalent_value_range;
-    return next_non_equivalent_value - 1;
+    return lowest_equivalent_value(value) + (size_of_equivalent_value_range(value) >> 1);
 }
 
-int64_t HdrHistogram::get_lowest_equivalent_value(int64_t value) const noexcept
+int64_t HdrHistogram::counts_get_normalised(int32_t index) const noexcept
 {
-    auto bucket_index = get_bucket_index(value);
-    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
-    auto lowest_equivalent_value = get_value_from_sub_bucket(bucket_index, sub_bucket_index);
-    return lowest_equivalent_value;
-}
-
-bool HdrHistogram::record(int64_t value, int count) noexcept
-{
-    auto counts_index = counts_index_for(value);
-    if (counts_len <= counts_index) {
-        return false;
-    }
-    counts_[counts_index] += count;
-    total_count_ += count;
-    min_value_ = std::min(min_value_, value);
-    max_value_ = std::max(max_value_, value);
-    return true;
+    return counts_[normalize_index(index)];
 }
 
 void HdrHistogram::reset() noexcept
@@ -192,120 +205,89 @@ void HdrHistogram::reset() noexcept
     fill(counts_.begin(), counts_.end(), 0);
 }
 
-int64_t HdrHistogram::get_value_from_sub_bucket(int64_t bucket_index,
-                                                int64_t sub_bucket_index) const noexcept
+bool HdrHistogram::record_value(int64_t value) noexcept
 {
-    return sub_bucket_index << (bucket_index + unit_magnitude);
+    return record_values(value, 1);
 }
 
-int64_t HdrHistogram::get_count_at_index(int64_t index) const
+bool HdrHistogram::record_values(int64_t value, int64_t count) noexcept
 {
-    // some decoded (read-only) histograms may have truncated
-    // counts arrays, we return zero for any index that is passed the array
-    //         if (index >= encoder.payload.counts_len){
-    //             return 0;
-    //         }
-    return counts_.at(index);
-}
-
-int64_t HdrHistogram::get_target_count_at_percentile(double percentile) const noexcept
-{
-    const auto requested_percentile = std::min(percentile, 100.0);
-    const int count_at_percentile = (requested_percentile * total_count_ / 100) + 0.5;
-    return std::max(count_at_percentile, 1);
-}
-
-int64_t HdrHistogram::counts_index_for(int64_t value) const noexcept
-{
-    auto bucket_index = get_bucket_index(value);
-    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
-    return counts_index(bucket_index, sub_bucket_index);
-}
-
-int64_t HdrHistogram::get_bucket_index(int64_t value) const noexcept
-{
-    // Smallest power of 2 containing value
-    auto pow2ceiling = 64 - __builtin_clzll(value | sub_bucket_mask);
-    return pow2ceiling - unit_magnitude - (sub_bucket_half_count_magnitude + 1);
-}
-
-int64_t HdrHistogram::get_sub_bucket_index(int64_t value, int64_t bucket_index) const noexcept
-{
-    return value >> (bucket_index + unit_magnitude);
-}
-
-int64_t HdrHistogram::get_value_from_index(int64_t index) const noexcept
-{
-    int bucket_index = (index >> sub_bucket_half_count_magnitude) - 1;
-    auto sub_bucket_index = (index & (sub_bucket_half_count - 1)) + sub_bucket_half_count;
-    if (bucket_index < 0) {
-        sub_bucket_index -= sub_bucket_half_count;
-        bucket_index = 0;
+    if (value < 0) {
+        return false;
     }
-    return get_value_from_sub_bucket(bucket_index, sub_bucket_index);
+    const int32_t counts_index{counts_index_for(value)};
+    if (counts_index < 0 || counts_len() <= counts_index) {
+        return false;
+    }
+    counts_inc_normalised(counts_index, count);
+    update_min_max(value);
+    return true;
 }
 
-int64_t HdrHistogram::counts_index(int bucket_index, int sub_bucket_index) const noexcept
+int32_t HdrHistogram::normalize_index(int32_t index) const noexcept
 {
-    // Calculate the index for the first entry in the bucket:
-    // (The following is the equivalent of ((bucket_index + 1) * subBucketHalfCount) ):
-    auto bucket_base_index = (bucket_index + 1) << sub_bucket_half_count_magnitude;
-    // Calculate the offset in the bucket:
-    auto offset_in_bucket = sub_bucket_index - sub_bucket_half_count;
+    if (normalizing_index_offset_ == 0) {
+        return index;
+    }
+
+    int32_t normalized_index{index - normalizing_index_offset_};
+
+    int32_t adjustment{0};
+    if (normalized_index < 0) {
+        adjustment = counts_len();
+    } else if (normalized_index >= counts_len()) {
+        adjustment = -counts_len();
+    }
+    return normalized_index + adjustment;
+}
+
+int32_t HdrHistogram::get_bucket_index(int64_t value) const noexcept
+{
+    // Smallest power of 2 containing value.
+    const int32_t pow2ceiling{64 - count_leading_zeros_64(value | sub_bucket_mask_)};
+    return pow2ceiling - unit_magnitude_ - (sub_bucket_half_count_magnitude_ + 1);
+}
+
+int32_t HdrHistogram::counts_index(int32_t bucket_index, int32_t sub_bucket_index) const noexcept
+{
+    // Calculate the index for the first entry in the bucket.
+    // The following is the equivalent of ((bucket_index + 1) * subBucketHalfCount)).
+    const int32_t bucket_base_index{(bucket_index + 1) << sub_bucket_half_count_magnitude_};
+    // Calculate the offset in the bucket.
+    const int32_t offset_in_bucket{sub_bucket_index - sub_bucket_half_count_};
     // The following is the equivalent of
-    //  ((sub_bucket_index  - subBucketHalfCount) + bucketBaseIndex
+    //  (sub_bucket_index  - subBucketHalfCount) + bucketBaseIndex).
     return bucket_base_index + offset_in_bucket;
 }
 
-int64_t HdrHistogram::hdr_size_of_equiv_value_range(int64_t value) const noexcept
+int32_t HdrHistogram::counts_index_for(int64_t value) const noexcept
 {
-    auto bucket_index = get_bucket_index(value);
-    auto sub_bucket_index = get_sub_bucket_index(value, bucket_index);
-    if (sub_bucket_index >= sub_bucket_count) {
-        ++bucket_index;
-    }
-    return 1 << (unit_magnitude + bucket_index);
+    const int32_t bucket_index{get_bucket_index(value)};
+    const int32_t sub_bucket_index{get_sub_bucket_index(value, bucket_index, unit_magnitude_)};
+    return counts_index(bucket_index, sub_bucket_index);
 }
 
-int64_t HdrHistogram::hdr_median_equiv_value(int64_t value) const noexcept
+int64_t HdrHistogram::non_zero_min() const noexcept
 {
-    return get_lowest_equivalent_value(value) + (hdr_size_of_equiv_value_range(value) >> 1);
+    if (min_value_ == numeric_limits<int64_t>::max()) {
+        return min_value_;
+    }
+    return lowest_equivalent_value(min_value_);
 }
 
-ostream& operator<<(ostream& out, const HdrHistogram& hist)
+void HdrHistogram::counts_inc_normalised(int32_t index, int64_t value) noexcept
 {
-    // TODO: Move to make_iterator functor
-    const double output_value_unit_scaling_ratio = 1000.0;
-    out << "       Value     Percentile TotalCount 1/(1-Percentile)\n\n";
-    for (const auto& iter_value : hist) {
-        const auto value = iter_value.value_iterated_to / output_value_unit_scaling_ratio;
-        const auto percentile = iter_value.percentile_level_iterated_to / 100;
-        const auto total_count = iter_value.total_count_to_this_value;
+    const int32_t normalised_index{normalize_index(index)};
+    counts_[normalised_index] += value;
+    total_count_ += value;
+}
 
-        // clang-format off
-        out << setw(12) << defaultfloat << setprecision(12) << value
-            << setw(15) << fixed << setprecision(12) << percentile
-            << setw(11) << defaultfloat << total_count;
-        // clang-format on
-
-        if (iter_value.percentile_level_iterated_to != 100) {
-            double other = 1.0 / (1.0 - iter_value.percentile_level_iterated_to / 100.0);
-            out << setw(17) << fixed << setprecision(2) << other;
-        }
-        out << '\n';
+void HdrHistogram::update_min_max(int64_t value) noexcept
+{
+    if (value != 0) {
+        min_value_ = std::min(min_value_, value);
     }
-
-    const double mean = hist.mean() / output_value_unit_scaling_ratio;
-    const double stddev = hist.stddev();
-    const double max = hist.max() / output_value_unit_scaling_ratio;
-    const double total = hist.get_total_count();
-
-    // clang-format off
-    return out <<
-        "#[Mean    = " << setw(14) << setprecision(14) << mean << ", StdDeviation   = " << setprecision(13) << stddev << "]\n"
-        "#[Max     = " << setw(14) << setprecision(14) << max << ", TotalCount     = " << total << "]\n"
-        "#[Buckets = " << setw(14) << hist.bucket_count << ", SubBuckets     = " << hist.sub_bucket_count << "]\n";
-    // clang-format on
+    max_value_ = std::max(max_value_, value);
 }
 
 } // namespace hdr

--- a/toolbox/hdr/Histogram.hpp
+++ b/toolbox/hdr/Histogram.hpp
@@ -15,29 +15,56 @@
 #ifndef TOOLBOX_HDR_HISTOGRAM
 #define TOOLBOX_HDR_HISTOGRAM
 
-#include "Iterator.hpp"
-
 #include <toolbox/Config.h>
 
-#include <cmath>
-#include <iomanip>
-#include <iostream>
-#include <limits>
+#include <cstdint>
 #include <vector>
 
 namespace toolbox {
+/// A C++ port of HdrHistogram_c written Michael Barker and released to the public domain.
 inline namespace hdr {
+/// Bucket configuration.
+struct TOOLBOX_API HdrBucketConfig {
+    /// Construct HdrBucketConfig.
+    ///
+    /// Due to the size of the histogram being the result of some reasonably involved math on the
+    /// input parameters.
+    ///
+    /// \param lowest_trackable_value The smallest possible value to be put into the histogram.
+    /// \param highest_trackable_value The largest possible value to be put into the histogram.
+    /// \param significant_figures The level of precision for this histogram, i.e. the number of
+    /// figures in a decimal number that will be maintained. E.g. a value of 3 will mean the results
+    /// from the histogram will be accurate up to the first three digits. Must be a value between 1
+    /// and 5 (inclusive).
+    HdrBucketConfig(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
+                    int significant_figures);
 
+    // Copy.
+    HdrBucketConfig(const HdrBucketConfig&) noexcept = default;
+    HdrBucketConfig& operator=(const HdrBucketConfig&) noexcept = default;
+
+    // Move.
+    HdrBucketConfig(HdrBucketConfig&&) noexcept = default;
+    HdrBucketConfig& operator=(HdrBucketConfig&&) noexcept = default;
+
+    std::int64_t lowest_trackable_value;
+    std::int64_t highest_trackable_value;
+    std::int32_t significant_figures;
+    std::int32_t unit_magnitude;
+    std::int32_t sub_bucket_half_count_magnitude;
+    std::int32_t sub_bucket_count;
+    std::int32_t sub_bucket_half_count;
+    std::int64_t sub_bucket_mask;
+    std::int32_t bucket_count;
+    std::int32_t counts_len;
+};
+
+/// A High Dynamic Range (HDR) Histogram.
 class TOOLBOX_API HdrHistogram {
-    friend class HdrIterator;
-    friend class RecordedIterator;
-    friend class PercentileIterator;
-    friend class AllValuesIterator;
-    friend std::ostream& operator<<(std::ostream& out, const HdrHistogram& hist);
-
   public:
-    HdrHistogram(std::int64_t lowest_value, std::int64_t highest_value,
-                 std::int64_t significant_figures);
+    HdrHistogram(const HdrBucketConfig& config);
+    HdrHistogram(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
+                 std::int32_t significant_figures);
 
     // Copy.
     HdrHistogram(const HdrHistogram&) = default;
@@ -47,66 +74,105 @@ class TOOLBOX_API HdrHistogram {
     HdrHistogram(HdrHistogram&&) noexcept = default;
     HdrHistogram& operator=(HdrHistogram&&) noexcept = default;
 
-    PercentileIterator begin() const;
-    PercentileIterator end() const;
+    std::int64_t lowest_trackable_value() const noexcept { return lowest_trackable_value_; }
+    std::int64_t highest_trackable_value() const noexcept { return highest_trackable_value_; }
+    std::int32_t significant_figures() const noexcept { return significant_figures_; }
 
-    std::int64_t percentile(double percentile) const;
+    std::int32_t sub_bucket_count() const noexcept { return sub_bucket_count_; }
+    std::int32_t bucket_count() const noexcept { return bucket_count_; }
+    std::int64_t total_count() const noexcept { return total_count_; }
+    std::int32_t counts_len() const noexcept { return static_cast<std::int32_t>(counts_.size()); }
 
-    /// Check whether two values are equivalent (meaning they
-    /// are in the same bucket/range)
-    /// Returns:
-    ///    true if the two values are equivalentv
-    std::int64_t values_are_equivalent(std::int64_t lhs, std::int64_t rhs) const noexcept;
-
-    std::int64_t max() const noexcept;
+    /// Get minimum value from the histogram. Will return 2^63-1 if the histogram is empty.
     std::int64_t min() const noexcept;
-    double mean() const noexcept;
-    double stddev() const noexcept;
 
-    std::int64_t get_count_at_value(std::int64_t value) const noexcept;
-    std::int64_t get_total_count() const noexcept;
+    /// Get maximum value from the histogram. Will return 0 if the histogram is empty.
+    std::int64_t max() const noexcept;
 
-    std::int64_t get_highest_equivalent_value(std::int64_t value) const noexcept;
-    std::int64_t get_lowest_equivalent_value(std::int64_t value) const noexcept;
+    /// Determine if two values are equivalent with the histogram's resolution. Where "equivalent"
+    /// means that value samples recorded for any two equivalent values are counted in a common
+    /// total count.
+    ///
+    /// \param a first value to compare.
+    /// \param b second value to compare.
+    /// \return true if values are equivalent with the histogram's resolution.
+    bool values_are_equivalent(std::int64_t a, std::int64_t b) const noexcept;
 
-    bool record(std::int64_t value, int count = 1) noexcept;
+    /// Get the lowest value that is equivalent to the given value within the histogram's
+    /// resolution. Where "equivalent" means that value samples recorded for any two equivalent
+    /// values are counted in a common total count.
+    ///
+    /// \param value The given value.
+    /// \return the lowest value that is equivalent to the given value within the histogram's
+    /// resolution.
+    std::int64_t lowest_equivalent_value(std::int64_t value) const noexcept;
+    std::int64_t highest_equivalent_value(std::int64_t value) const noexcept;
+
+    /// Get the count of recorded values at a specific value (to within the histogram resolution at
+    /// the value level).
+    ///
+    /// \param value The value for which to provide the recorded count.
+    /// \return The total count of values recorded in the histogram within the value range.
+    std::int64_t count_at_value(std::int64_t value) const noexcept;
+    std::int64_t count_at_index(std::int32_t index) const noexcept;
+    std::int64_t value_at_index(std::int32_t index) const noexcept;
+    std::int64_t size_of_equivalent_value_range(std::int64_t value) const noexcept;
+    std::int64_t next_non_equivalent_value(std::int64_t value) const noexcept;
+    std::int64_t median_equivalent_value(std::int64_t value) const noexcept;
+    std::int64_t counts_get_normalised(std::int32_t index) const noexcept;
+
+    /// Reset a histogram to zero - empty out a histogram and re-initialise it.
+    ///
+    /// If you want to re-use an existing histogram, but reset everything back to zero, this is the
+    /// routine to use.
+    ///
+    /// \param h The histogram you want to reset to empty.
     void reset() noexcept;
 
-    std::int64_t unit_magnitude;
-    std::int64_t sub_bucket_half_count_magnitude;
-    std::int64_t sub_bucket_count;
-    std::int64_t sub_bucket_half_count;
-    std::int64_t sub_bucket_mask;
-    std::int64_t bucket_count;
-    std::int64_t counts_len;
+    /// Records a value in the histogram, will round this value of to a precision at or better than
+    /// the significant_figure specified at construction time.
+    ///
+    /// \param value Value to add to the histogram.
+    /// \return false if the value is larger than the highest_trackable_value and can't be recorded,
+    /// true otherwise.
+    bool record_value(std::int64_t value) noexcept;
+
+    /// Records count values in the histogram, will round this value of to a precision at or better
+    /// than the significant_figure specified at construction time.
+    ///
+    /// \param value Value to add to the histogram.
+    /// \param count Number of values to add to the histogram.
+    /// \return false if any value is larger than the highest_trackable_value and can't be recorded,
+    /// true otherwise.
+    bool record_values(std::int64_t value, std::int64_t count) noexcept;
 
   private:
-    std::int64_t get_value_from_sub_bucket(std::int64_t bucket_index,
-                                           std::int64_t sub_bucket_index) const noexcept;
-    std::int64_t get_count_at_index(std::int64_t index) const;
-    std::int64_t get_target_count_at_percentile(double percentile) const noexcept;
-    std::int64_t counts_index_for(std::int64_t value) const noexcept;
+    std::int32_t normalize_index(std::int32_t index) const noexcept;
+    std::int32_t get_bucket_index(std::int64_t value) const noexcept;
+    std::int32_t counts_index(std::int32_t bucket_index, std::int32_t sub_bucket_index) const
+        noexcept;
+    std::int32_t counts_index_for(std::int64_t value) const noexcept;
+    std::int64_t non_zero_min() const noexcept;
 
-    std::int64_t get_bucket_index(std::int64_t value) const noexcept;
-    std::int64_t get_sub_bucket_index(std::int64_t value, std::int64_t bucket_index) const noexcept;
+    void counts_inc_normalised(std::int32_t index, std::int64_t value) noexcept;
+    void update_min_max(std::int64_t value) noexcept;
 
-    std::int64_t get_value_from_index(std::int64_t index) const noexcept;
-    std::int64_t counts_index(int bucket_index, int sub_bucket_index) const noexcept;
+    std::int64_t lowest_trackable_value_;
+    std::int64_t highest_trackable_value_;
+    std::int32_t significant_figures_;
+    std::int32_t unit_magnitude_;
+    std::int32_t sub_bucket_half_count_magnitude_;
+    std::int32_t sub_bucket_count_;
+    std::int32_t sub_bucket_half_count_;
+    std::int64_t sub_bucket_mask_;
+    std::int32_t bucket_count_;
 
-    std::int64_t hdr_size_of_equiv_value_range(std::int64_t value) const noexcept;
-    std::int64_t hdr_median_equiv_value(std::int64_t value) const noexcept;
-
-    std::int64_t min_value_{std::numeric_limits<std::int64_t>::max()};
-    std::int64_t max_value_{0};
-
-    std::int64_t total_count_{0};
+    std::int32_t normalizing_index_offset_;
+    std::int64_t min_value_;
+    std::int64_t max_value_;
+    std::int64_t total_count_;
     std::vector<std::int64_t> counts_;
-
-    // FIXME: what is the purpose of this data member?
-    static constexpr double int_to_double_conversion_ratio_{1.0};
 };
-
-TOOLBOX_API std::ostream& operator<<(std::ostream& out, const HdrHistogram& hist);
 
 } // namespace hdr
 } // namespace toolbox

--- a/toolbox/hdr/Iterator.ut.cpp
+++ b/toolbox/hdr/Iterator.ut.cpp
@@ -1,0 +1,57 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Utility.hpp"
+
+#include "Histogram.hpp"
+#include "Iterator.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <cmath>
+
+using namespace std;
+using namespace toolbox;
+
+BOOST_AUTO_TEST_SUITE(IteratorSuite)
+
+BOOST_AUTO_TEST_CASE(IteratorLinearIteratorCase)
+{
+    HdrHistogram h{1, 255, 2};
+    BOOST_TEST(h.record_value(193));
+    BOOST_TEST(h.record_value(255));
+    BOOST_TEST(h.record_value(0));
+    BOOST_TEST(h.record_value(1));
+    BOOST_TEST(h.record_value(64));
+    BOOST_TEST(h.record_value(128));
+
+    int step_count{0};
+    int64_t total_count{0};
+
+    HdrLinearIterator iter{h, 64};
+    while (iter.next()) {
+        total_count += iter.count_added_in_this_iteration_step();
+        if (step_count == 0) {
+            h.record_value(2);
+        }
+        ++step_count;
+    }
+
+    BOOST_TEST(step_count == 4);
+    BOOST_TEST(total_count == 6);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/hdr/Utility.cpp
+++ b/toolbox/hdr/Utility.cpp
@@ -1,0 +1,142 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Utility.hpp"
+
+#include "Histogram.hpp"
+#include "Iterator.hpp"
+
+#include <boost/io/ios_state.hpp>
+
+#include <cmath>
+#include <iomanip>
+#include <ostream>
+
+namespace toolbox {
+inline namespace hdr {
+using namespace std;
+namespace {
+int64_t get_count_at_percentile(const HdrHistogram& h, double percentile) noexcept
+{
+    if (percentile > 100.0) {
+        percentile = 100.0;
+    }
+    const int count_at_percentile = (percentile * h.total_count() / 100) + 0.5;
+    return std::max<int64_t>(count_at_percentile, 1);
+}
+} // namespace
+
+int64_t min(const HdrHistogram& h) noexcept
+{
+    return h.min();
+}
+
+int64_t max(const HdrHistogram& h) noexcept
+{
+    return h.max();
+}
+
+int64_t value_at_percentile(const HdrHistogram& h, double percentile) noexcept
+{
+    const int64_t count_at_percentile{get_count_at_percentile(h, percentile)};
+
+    int64_t total{0};
+    HdrIterator iter{h};
+    while (iter.next()) {
+        total += iter.count();
+        if (total >= count_at_percentile) {
+            return h.highest_equivalent_value(iter.value());
+        }
+    }
+    return 0;
+}
+
+double mean(const HdrHistogram& h) noexcept
+{
+    const auto total_count = h.total_count();
+
+    int64_t total{0};
+    HdrIterator iter{h};
+    while (iter.next()) {
+        if (iter.count() != 0) {
+            total += iter.count() * h.median_equivalent_value(iter.value());
+        }
+    }
+    return double(total) / total_count;
+}
+
+double stddev(const HdrHistogram& h) noexcept
+{
+    const int64_t total_count{h.total_count()};
+    const double mean_val{mean(h)};
+
+    double geometric_dev_total{0.0};
+    HdrIterator iter{h};
+    while (iter.next()) {
+        if (iter.count() != 0) {
+            const double dev{h.median_equivalent_value(iter.value()) - mean_val};
+            geometric_dev_total += (dev * dev) * iter.count();
+        }
+    }
+    return sqrt(geometric_dev_total / total_count);
+}
+
+ostream& operator<<(ostream& os, PutPercentiles pp)
+{
+    const auto sf = pp.h.significant_figures();
+    boost::io::ios_all_saver all_saver{os};
+
+    os << "       Value     Percentile TotalCount 1/(1-Percentile)\n\n";
+
+    HdrPercentileIterator iter{pp.h, pp.ticks_per_half_distance};
+    while (iter.next()) {
+        const double value{iter.highest_equivalent_value() / pp.value_scale};
+        const double percentile{iter.percentile() / 100.0};
+        const int64_t total_count{iter.cumulative_count()};
+
+        // clang-format off
+        os << setw(12) << fixed << setprecision(sf) << value
+           << setw(15) << fixed << setprecision(6) << percentile
+           << setw(11) << total_count;
+        // clang-format on
+
+        if (percentile < 1.0) {
+            const double inverted_percentile{(1.0 / (1.0 - percentile))};
+            os << setw(15) << fixed << setprecision(2) << inverted_percentile;
+        }
+        os << '\n';
+    }
+
+    const double mean_val{mean(pp.h) / pp.value_scale};
+    const double stddev_val{stddev(pp.h)};
+    const double max_val{pp.h.max() / pp.value_scale};
+    const int64_t total_val{pp.h.total_count()};
+
+    // clang-format off
+    return os
+        << "#[Mean    = " << setw(12) << fixed << setprecision(sf) << mean_val
+        << ", StdDeviation   = " << setw(12) << fixed << setprecision(sf) << stddev_val
+        << "]\n"
+        "#[Max     = " << setw(12) << fixed << setprecision(sf) << max_val
+        << ", TotalCount     = " << setw(12) << total_val
+        << "]\n"
+        "#[Buckets = " << setw(12) << pp.h.bucket_count()
+        << ", SubBuckets     = " << setw(12) << pp.h.sub_bucket_count()
+        << "]";
+    // clang-format on
+}
+
+} // namespace hdr
+} // namespace toolbox

--- a/toolbox/hdr/Utility.hpp
+++ b/toolbox/hdr/Utility.hpp
@@ -1,0 +1,67 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef TOOLBOX_HDR_UTILITY
+#define TOOLBOX_HDR_UTILITY
+
+#include <toolbox/Config.h>
+
+#include <cstdint>
+#include <iosfwd>
+
+namespace toolbox {
+/// A C++ port of HdrHistogram_c written Michael Barker and released to the public domain.
+inline namespace hdr {
+class HdrHistogram;
+
+TOOLBOX_API std::int64_t min(const HdrHistogram& h) noexcept;
+TOOLBOX_API std::int64_t max(const HdrHistogram& h) noexcept;
+
+/// Get the value at a specific percentile.
+///
+/// \param h The histogram.
+/// \param percentile The percentile to get the value for.
+/// \return the percentile value.
+TOOLBOX_API std::int64_t value_at_percentile(const HdrHistogram& h, double percentile) noexcept;
+
+/// Gets the mean for the values in the histogram.
+///
+/// \param h The histogram.
+/// \return the mean.
+TOOLBOX_API double mean(const HdrHistogram& h) noexcept;
+
+/// Gets the standard deviation for the values in the histogram.
+///
+/// \param h The histogram.
+/// \return the standard deviation.
+TOOLBOX_API double stddev(const HdrHistogram& h) noexcept;
+
+struct PutPercentiles {
+    const HdrHistogram& h;
+    std::int32_t ticks_per_half_distance{5};
+    double value_scale{1000.0};
+};
+
+inline auto put_percentiles(const HdrHistogram& h, std::int32_t ticks_per_half_distance,
+                            double value_scale) noexcept
+{
+    return PutPercentiles{h, ticks_per_half_distance, value_scale};
+}
+
+TOOLBOX_API std::ostream& operator<<(std::ostream& os, PutPercentiles pp);
+
+} // namespace hdr
+} // namespace toolbox
+
+#endif // TOOLBOX_HDR_UTILITY

--- a/toolbox/hdr/Utility.ut.cpp
+++ b/toolbox/hdr/Utility.ut.cpp
@@ -1,0 +1,86 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Utility.hpp"
+
+#include "Histogram.hpp"
+#include "Iterator.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <cmath>
+
+using namespace std;
+using namespace toolbox;
+
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_SUITE(UtilitySuite)
+
+BOOST_AUTO_TEST_CASE(CreateWithLargeValuesCase)
+{
+    HdrHistogram h{20000000, 100000000, 5};
+    BOOST_TEST(h.record_value(100000000));
+    BOOST_TEST(h.record_value(20000000));
+    BOOST_TEST(h.record_value(30000000));
+
+    BOOST_TEST(h.values_are_equivalent(value_at_percentile(h, 50.0), 20000000));
+    BOOST_TEST(h.values_are_equivalent(value_at_percentile(h, 83.33), 30000000));
+    BOOST_TEST(h.values_are_equivalent(value_at_percentile(h, 83.34), 100000000));
+    BOOST_TEST(h.values_are_equivalent(value_at_percentile(h, 99.0), 100000000));
+}
+
+BOOST_AUTO_TEST_CASE(HighSignificantFiguresCase)
+{
+    const std::initializer_list<int64_t> vals{459876,  669187,  711612,  816326,  931423,
+                                              1033197, 1131895, 2477317, 3964974, 12718782};
+    HdrHistogram h{459876, 12718782, 5};
+    for (const auto val : vals) {
+        BOOST_TEST(h.record_value(val));
+    }
+    BOOST_TEST(value_at_percentile(h, 50) == 1048575);
+}
+
+BOOST_AUTO_TEST_CASE(NaNCase)
+{
+    HdrHistogram h{1, 100000, 3};
+    BOOST_TEST(isnan(mean(h)));
+    BOOST_TEST(isnan(stddev(h)));
+}
+
+BOOST_AUTO_TEST_CASE(StatsCase)
+{
+    HdrHistogram h{1, 10000000, 3};
+    for (int i{0}; i < 1000000; ++i) {
+        BOOST_TEST(h.record_value(i));
+    }
+
+    BOOST_TEST(h.min() == 0);
+    BOOST_TEST(h.max() == 1000447);
+
+    BOOST_TEST(value_at_percentile(h, 50) == 500223);
+    BOOST_TEST(value_at_percentile(h, 75) == 750079);
+    BOOST_TEST(value_at_percentile(h, 90) == 900095);
+    BOOST_TEST(value_at_percentile(h, 95) == 950271);
+    BOOST_TEST(value_at_percentile(h, 99) == 990207);
+    BOOST_TEST(value_at_percentile(h, 99.9) == 999423);
+    BOOST_TEST(value_at_percentile(h, 99.99) == 999935);
+
+    BOOST_TEST(mean(h) == 500000.013312);
+    BOOST_TEST(stddev(h) == 288675.1403682715);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Refactor hdr package, so that it is more closely aligned to HdrHistogram_c. The advantage being that upstream bug fixes are easier to track and integrate into the C++ port.

Statistical functions that depend on iterators have been moved to a separate file in order to break a cyclic dependency between files.

Improve unit-test coverage has also been improved in this commit.
