### PR TITLE
Path and thread affinity enhancements

### DIFF
--- a/etc/cppcheck-suppressions.txt
+++ b/etc/cppcheck-suppressions.txt
@@ -1,4 +1,5 @@
 cppcheckError:*/toolbox/util/IntTypes.ut.cpp
+syntaxError:*/toolbox/sys/Thread.cpp
 preprocessorErrorDirective:*/toolbox/net/Error.cpp
 preprocessorErrorDirective:*/toolbox/sys/Error.cpp
 returnDanglingLifetime:*/toolbox/io/Timer.cpp

--- a/example/EchoClnt.cpp
+++ b/example/EchoClnt.cpp
@@ -188,8 +188,8 @@ int main(int argc, char* argv[])
 
         // Start service threads.
         pthread_setname_np(pthread_self(), "main");
-        ReactorRunner reactor_runner{reactor, ThreadConfig{"reactor"s}};
-        ResolverRunner resolver_runner{resolver, ThreadConfig{"resolver"s}};
+        ReactorRunner reactor_runner{reactor, "reactor"s};
+        ResolverRunner resolver_runner{resolver, "resolver"s};
 
         // Wait for termination.
         SigWait sig_wait;

--- a/example/EchoServ.cpp
+++ b/example/EchoServ.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
 
         // Start service threads.
         pthread_setname_np(pthread_self(), "main");
-        ReactorRunner reactor_runner{reactor, ThreadConfig{"reactor"s}};
+        ReactorRunner reactor_runner{reactor, "reactor"s};
 
         // Wait for termination.
         SigWait sig_wait;

--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
 
         // Start service threads.
         pthread_setname_np(pthread_self(), "main");
-        ReactorRunner reactor_runner{reactor, ThreadConfig{"reactor"s}};
+        ReactorRunner reactor_runner{reactor, "reactor"s};
 
         // Wait for termination.
         SigWait sig_wait;

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -220,6 +220,7 @@ set(test_SOURCES
   net/Socket.ut.cpp
   sys/Date.ut.cpp
   sys/Log.ut.cpp
+  sys/Thread.ut.cpp
   sys/Time.ut.cpp
   util/Argv.ut.cpp
   util/Array.ut.cpp

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -104,7 +104,8 @@ set(lib_SOURCES
   util/Math.cpp
   util/MemAlloc.cpp
   util/Options.cpp
-  util/RefCount.cpp
+  util/Options.cpp
+  util/Path.cpp
   util/RingBuffer.cpp
   util/Ryu.cpp
   util/Slot.cpp
@@ -230,6 +231,7 @@ set(test_SOURCES
   util/Math.ut.cpp
   util/MemAlloc.ut.cpp
   util/Options.ut.cpp
+  util/Path.ut.cpp
   util/RefCount.ut.cpp
   util/RingBuffer.ut.cpp
   util/Ryu.ut.cpp
@@ -248,7 +250,8 @@ set(test_SOURCES
 add_executable(toolbox-test
   ${test_SOURCES}
   Main.ut.cpp)
-target_link_libraries(toolbox-test ${toolbox_LIBRARY} "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}")
+target_link_libraries(toolbox-test
+  ${toolbox_LIBRARY} "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}" stdc++fs)
 
 foreach(file ${test_SOURCES})
   get_filename_component(dir  "${file}" DIRECTORY)

--- a/toolbox/hdr/Histogram.ut.cpp
+++ b/toolbox/hdr/Histogram.ut.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(HistogramOutOfRangeCase)
 BOOST_AUTO_TEST_CASE(HistogramResetCase)
 {
     HdrHistogram h{1, 10000000, 3};
-    for (int i{0}; i < 1000000; ++i) {
+    for (int i{0}; i < 1000; ++i) {
         BOOST_TEST(h.record_value(i));
     }
     h.reset();
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(HistogramResetCase)
 BOOST_AUTO_TEST_CASE(HistogramTotalCountCase)
 {
     HdrHistogram h{1, 10000000, 3};
-    for (int i{0}; i < 1000000; ++i) {
+    for (int i{0}; i < 1000; ++i) {
         BOOST_TEST(h.record_value(i));
         BOOST_TEST(h.total_count() == i + 1);
     }

--- a/toolbox/hdr/Utility.ut.cpp
+++ b/toolbox/hdr/Utility.ut.cpp
@@ -63,24 +63,24 @@ BOOST_AUTO_TEST_CASE(NaNCase)
 
 BOOST_AUTO_TEST_CASE(StatsCase)
 {
-    HdrHistogram h{1, 10000000, 3};
-    for (int i{0}; i < 1000000; ++i) {
+    HdrHistogram h{1, 100000, 4};
+    for (int i{1}; i <= 100000; ++i) {
         BOOST_TEST(h.record_value(i));
     }
 
-    BOOST_TEST(h.min() == 0);
-    BOOST_TEST(h.max() == 1000447);
+    BOOST_TEST(h.min() == 1);
+    BOOST_TEST(h.max() == 100003);
 
-    BOOST_TEST(value_at_percentile(h, 50) == 500223);
-    BOOST_TEST(value_at_percentile(h, 75) == 750079);
-    BOOST_TEST(value_at_percentile(h, 90) == 900095);
-    BOOST_TEST(value_at_percentile(h, 95) == 950271);
-    BOOST_TEST(value_at_percentile(h, 99) == 990207);
-    BOOST_TEST(value_at_percentile(h, 99.9) == 999423);
-    BOOST_TEST(value_at_percentile(h, 99.99) == 999935);
+    BOOST_TEST(value_at_percentile(h, 50) == 50001);
+    BOOST_TEST(value_at_percentile(h, 75) == 75003);
+    BOOST_TEST(value_at_percentile(h, 90) == 90003);
+    BOOST_TEST(value_at_percentile(h, 95) == 95003);
+    BOOST_TEST(value_at_percentile(h, 99) == 99003);
+    BOOST_TEST(value_at_percentile(h, 99.9) == 99903);
+    BOOST_TEST(value_at_percentile(h, 99.99) == 99991);
 
-    BOOST_TEST(mean(h) == 500000.013312);
-    BOOST_TEST(stddev(h) == 288675.1403682715);
+    BOOST_TEST(mean(h) == 50000.836179999998);
+    BOOST_TEST(stddev(h) == 28867.704262911586);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/io/Runner.cpp
+++ b/toolbox/io/Runner.cpp
@@ -27,9 +27,9 @@ namespace {
 void run_reactor(Reactor& r, ThreadConfig config, const std::atomic<bool>& stop)
 {
     sig_block_all();
-    pthread_setname_np(pthread_self(), config.name.c_str());
-    TOOLBOX_NOTICE << "started " << config.name << " thread";
     try {
+        set_thread_attrs(config);
+        TOOLBOX_NOTICE << "started " << config.name << " thread";
         while (!stop.load(std::memory_order_acquire)) {
             r.poll(CyclTime::now());
         }

--- a/toolbox/net/Runner.cpp
+++ b/toolbox/net/Runner.cpp
@@ -29,9 +29,9 @@ namespace {
 void run_resolver(Resolver& r, ThreadConfig config)
 {
     sig_block_all();
-    pthread_setname_np(pthread_self(), config.name.c_str());
-    TOOLBOX_NOTICE << "started " << config.name << " thread";
     try {
+        set_thread_attrs(config);
+        TOOLBOX_NOTICE << "started " << config.name << " thread";
         // The run() function returns -1 when resolver is closed.
         while (r.run() >= 0)
             ;

--- a/toolbox/net/Runner.ut.cpp
+++ b/toolbox/net/Runner.ut.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(ResolverRunnerCase)
     Resolver res;
 
     pthread_setname_np(pthread_self(), "main");
-    ResolverRunner resolver_runner{res, ThreadConfig{"resolver"s}};
+    ResolverRunner resolver_runner{res, "resolver"s};
 
     const auto uri1 = "tcp4://192.168.1.3:443"s;
     const auto uri2 = "tcp6://[fe80::c8bf:7d86:cbdc:bda9]:443"s;

--- a/toolbox/sys/Thread.hpp
+++ b/toolbox/sys/Thread.hpp
@@ -24,9 +24,46 @@
 namespace toolbox {
 inline namespace sys {
 
+/// ThreadConfig holds the thread attributes.
 struct ThreadConfig {
+    ThreadConfig(std::string name, std::string affinity) noexcept
+    : name{std::move(name)}
+    , affinity{std::move(affinity)}
+    {
+    }
+    ThreadConfig(std::string name) noexcept
+    : name{std::move(name)}
+    {
+    }
+    ThreadConfig() noexcept = default;
+
+    // Copy.
+    ThreadConfig(const ThreadConfig&) = default;
+    ThreadConfig& operator=(const ThreadConfig&) = default;
+
+    // Move.
+    ThreadConfig(ThreadConfig&&) noexcept = default;
+    ThreadConfig& operator=(ThreadConfig&&) noexcept = default;
+
+    /// The thread's name.
     std::string name;
+    /// The thread's affinity.
+    std::string affinity;
 };
+
+/// Parse an isolcpus-style set of CPUs.
+///
+/// The CPU set is either a list: "<cpu>,...,<cpu>", or a range: "<cpu>-<cpu>", or a combination or
+/// both: "<cpu>,...,<cpu>-<cpu>", where "<cpu>" begins at 0 and the maximum value is "number of
+/// CPUs in system - 1". For example: "0,1,10-11,22-23".
+///
+/// \param s An isolcpus-style set of CPUs.
+/// \return a copy of the CPU set.
+TOOLBOX_API cpu_set_t parse_cpu_set(std::string_view s) noexcept;
+
+/// Set attributes for current thread from config.
+/// \param config The configuration.
+TOOLBOX_API void set_thread_attrs(const ThreadConfig& config);
 
 } // namespace sys
 } // namespace toolbox

--- a/toolbox/sys/Thread.ut.cpp
+++ b/toolbox/sys/Thread.ut.cpp
@@ -1,0 +1,49 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Thread.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace toolbox;
+
+namespace {
+uint32_t to_bitset(const cpu_set_t& cpuset) noexcept
+{
+    uint32_t bs{0};
+    for (int i{0}; i < 32; ++i) {
+        if (CPU_ISSET(i, &cpuset)) {
+            bs |= (1 << i);
+        }
+    }
+    return bs;
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(ThreadSuite)
+
+BOOST_AUTO_TEST_CASE(ThreadParseCpuSetCase)
+{
+    BOOST_TEST(to_bitset(parse_cpu_set(""sv)) == 0b0);
+    BOOST_TEST(to_bitset(parse_cpu_set("0"sv)) == 0b1);
+    BOOST_TEST(to_bitset(parse_cpu_set("1,2"sv)) == 0b110);
+    BOOST_TEST(to_bitset(parse_cpu_set("0-3"sv)) == 0b1111);
+    BOOST_TEST(to_bitset(parse_cpu_set("1,2,4-7"sv)) == 0b11110110);
+    BOOST_TEST(to_bitset(parse_cpu_set("0-3,5,6,8-11"sv)) == 0b111101101111);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/util.hpp
+++ b/toolbox/util.hpp
@@ -28,6 +28,7 @@
 #include "util/Math.hpp"
 #include "util/MemAlloc.hpp"
 #include "util/Options.hpp"
+#include "util/Path.hpp"
 #include "util/RefCount.hpp"
 #include "util/RingBuffer.hpp"
 #include "util/Ryu.hpp"

--- a/toolbox/util/Path.cpp
+++ b/toolbox/util/Path.cpp
@@ -1,0 +1,17 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Path.hpp"

--- a/toolbox/util/Path.hpp
+++ b/toolbox/util/Path.hpp
@@ -1,0 +1,37 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOOLBOX_UTIL_PATH_HPP
+#define TOOLBOX_UTIL_PATH_HPP
+
+#include <toolbox/util/TypeTraits.hpp>
+
+#include <experimental/filesystem>
+
+namespace toolbox {
+inline namespace util {
+using Path = std::experimental::filesystem::path;
+
+template <>
+struct TypeTraits<Path> {
+    static auto from_string(std::string_view sv) noexcept { return Path{sv}; }
+    static auto from_string(const std::string& s) noexcept { return Path{s}; }
+};
+
+} // namespace util
+} // namespace toolbox
+
+#endif // TOOLBOX_UTIL_PATH_HPP

--- a/toolbox/util/Path.ut.cpp
+++ b/toolbox/util/Path.ut.cpp
@@ -1,0 +1,33 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Path.hpp"
+
+#include <toolbox/util/String.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace toolbox;
+
+BOOST_AUTO_TEST_SUITE(PathSuite)
+
+BOOST_AUTO_TEST_CASE(FromStringCase)
+{
+    BOOST_TEST(from_string<Path>("/a/b/c") == Path{"/a/b/c"});
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR provides the following enhancements as separate commits:

1) Specialise TypeTraits for filesystem path

The ThreadConfig structure should be extended to include an isolcpus-style affinity mask, along with helper functions for parsing and setting thread affinity.

2) Extend thread config to include affinity

Add TypeTraits specialisation for filesystem paths, so that paths can be specified as arguments to command-line options.
