### PR TITLE
bug: the hex_digits function is broken on ARM32 builds

### DIFF
--- a/bench/Util.bm.cpp
+++ b/bench/Util.bm.cpp
@@ -94,7 +94,6 @@ int dec_digits_less(int64_t i) noexcept
     return 19;
 }
 
-int hex_digits_bitshift(int64_t i) noexcept __attribute__((noinline));
 int hex_digits_bitshift(int64_t i) noexcept
 {
     int n{0};

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -95,6 +95,7 @@ set(lib_SOURCES
   util/Alarm.cpp
   util/Argv.cpp
   util/Array.cpp
+  util/Bits.cpp
   util/Compare.cpp
   util/Config.cpp
   util/Enum.cpp

--- a/toolbox/util.hpp
+++ b/toolbox/util.hpp
@@ -19,6 +19,7 @@
 
 #include "util/Argv.hpp"
 #include "util/Array.hpp"
+#include "util/Bits.hpp"
 #include "util/Compare.hpp"
 #include "util/Config.hpp"
 #include "util/Enum.hpp"

--- a/toolbox/util/Bits.cpp
+++ b/toolbox/util/Bits.cpp
@@ -1,0 +1,17 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Bits.hpp"

--- a/toolbox/util/Bits.hpp
+++ b/toolbox/util/Bits.hpp
@@ -1,0 +1,47 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2019 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOOLBOX_UTIL_BITS_HPP
+#define TOOLBOX_UTIL_BITS_HPP
+
+namespace toolbox {
+inline namespace util {
+
+/// Returns the number of leading 0-bits, starting at the most significant bit position. The result
+/// is undefined for zero values.
+///
+/// \tparam ValueT Integer type.
+/// \param i Integer value.
+/// \return the number of leading 0-bits.
+template <typename IntegerT>
+constexpr auto clz(IntegerT i) noexcept
+{
+    if constexpr (sizeof(i) <= sizeof(int)) {
+        return __builtin_clz(i);
+    } else if constexpr (sizeof(i) <= sizeof(long)) {
+        return __builtin_clzl(i);
+    } else {
+        return __builtin_clzll(i);
+    }
+}
+
+static_assert(clz(~0) == 0);
+static_assert(clz(1) == 31);
+
+} // namespace util
+} // namespace toolbox
+
+#endif // TOOLBOX_UTIL_BITS_HPP

--- a/toolbox/util/Math.hpp
+++ b/toolbox/util/Math.hpp
@@ -17,6 +17,8 @@
 #ifndef TOOLBOX_UTIL_MATH_HPP
 #define TOOLBOX_UTIL_MATH_HPP
 
+#include <toolbox/util/Bits.hpp>
+
 #include <toolbox/Config.h>
 
 #include <algorithm>
@@ -34,15 +36,15 @@ constexpr bool is_pow2(std::size_t n) noexcept
 /// \return the next power of two.
 inline unsigned next_pow2(unsigned n) noexcept
 {
-    // The result of __builtin_clz is undefined for zero values.
-    return n <= 1 ? 1 : 1 << (sizeof(n) * 8 - __builtin_clz(n - 1));
+    // The result of clz is undefined for zero values.
+    return n <= 1 ? 1 : 1 << (sizeof(n) * 8 - clz(n - 1));
 }
 
 /// \return the next power of two.
 inline unsigned long next_pow2(unsigned long n) noexcept
 {
-    // The result of __builtin_clzl is undefined for zero values.
-    return n <= 1 ? 1 : 1 << (sizeof(n) * 8 - __builtin_clzl(n - 1));
+    // The result of clz is undefined for zero values.
+    return n <= 1 ? 1 : 1 << (sizeof(n) * 8 - clz(n - 1));
 }
 
 template <int BitsN>

--- a/toolbox/util/Tuple.ut.cpp
+++ b/toolbox/util/Tuple.ut.cpp
@@ -38,14 +38,13 @@ BOOST_AUTO_TEST_CASE(TupleApplyCase)
     expected = std::string{"foo"};
     toolbox::tuple_apply<2>(tuple, fn);
     BOOST_TEST(res == expected);
-
 }
 
 BOOST_AUTO_TEST_CASE(TupleForEachCase)
 {
     auto sstr = std::ostringstream();
     auto tuple = std::make_tuple(123, 45.6, "foo", " ", "bar");
-    toolbox::tuple_for_each(tuple, [&sstr](const auto& v){ sstr << v; });
+    toolbox::tuple_for_each(tuple, [&sstr](const auto& v) { sstr << v; });
     auto expected = std::string{"12345.6foo bar"};
     BOOST_TEST(sstr.str() == expected);
 }

--- a/toolbox/util/Utility.cpp
+++ b/toolbox/util/Utility.cpp
@@ -35,11 +35,6 @@ int dec_digits(int64_t i) noexcept
                                      : i < 1000000000000000000 ? 18 : 19;
 }
 
-int hex_digits(int64_t i) noexcept
-{
-    return 1 + ((63 - __builtin_clzl(i | 1)) / 4);
-}
-
 bool stob(string_view sv, bool dfl) noexcept
 {
     bool val{dfl};

--- a/toolbox/util/Utility.hpp
+++ b/toolbox/util/Utility.hpp
@@ -17,6 +17,8 @@
 #ifndef TOOLBOX_UTIL_UTILITY_HPP
 #define TOOLBOX_UTIL_UTILITY_HPP
 
+#include <toolbox/util/Bits.hpp>
+
 #include <toolbox/Config.h>
 
 #include <cstdint>
@@ -25,6 +27,9 @@
 
 namespace toolbox {
 inline namespace util {
+
+static_assert(clz(std::int32_t{1}) == 31);
+static_assert(clz(std::int64_t{1}) == 63);
 
 template <typename T>
 struct AlwaysFalse : std::false_type {
@@ -43,12 +48,28 @@ constexpr bool isdigit(int c) noexcept
 static_assert(isdigit('0') && isdigit('9') && !isdigit('A'));
 
 /// Returns the number of decimal digits in a positive, signed integer.
+///
+/// \param i Integer value.
+/// \return the number of decimal digits.
 /// \todo consider adding support for negative integers.
-TOOLBOX_API int dec_digits(int64_t i) noexcept;
+TOOLBOX_API int dec_digits(std::int64_t i) noexcept;
 
-/// Returns the number of hexadecimal digits in a positive, signed integer.
+/// Returns the number of hexadecimal digits in a positive integer.
+///
+/// \tparam IntegerT Integer type.
+/// \param i Integer value.
+/// \return the number of hexadecimal digits.
 /// \todo consider adding support for negative integers.
-TOOLBOX_API int hex_digits(int64_t i) noexcept;
+template <typename IntegerT>
+constexpr int hex_digits(IntegerT i) noexcept
+{
+    constexpr auto Bits = sizeof(i) * 8;
+    return 1 + ((Bits - clz(i | 1) - 1) >> 2);
+}
+
+static_assert(hex_digits(0x0) == 1);
+static_assert(hex_digits(0x1) == 1);
+static_assert(hex_digits(std::int64_t{0xffffffffffff}) == 12);
 
 TOOLBOX_API bool stob(std::string_view sv, bool dfl = false) noexcept;
 TOOLBOX_API double stod(std::string_view sv) noexcept;


### PR DESCRIPTION
The hex_digits function was using the long version of the bultin clz function (`__builtin_clzl`). Long integers are 32-bits on ARM32. A function template has been added to ensure that the correct intrinsic is used in future based on the size of the integer type.

Closes #51