### PR TITLE
chore(doxygen): move Doxygen target to doc directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,20 +133,6 @@ endif()
 
 find_package(Doxygen) # Optional.
 
-if(DOXYGEN_FOUND)
-  configure_file("${PROJECT_SOURCE_DIR}/Doxyfile.in"
-    "${PROJECT_BINARY_DIR}/Doxyfile" @ONLY)
-
-  add_custom_target(toolbox-doc
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    COMMAND "${DOXYGEN_EXECUTABLE}" "${PROJECT_BINARY_DIR}/Doxyfile"
-    COMMAND "${CMAKE_COMMAND}" -E echo docs.toolbox.reactivemarkets.com
-           >"${PROJECT_BINARY_DIR}/doc/html/CNAME"
-    SOURCES "${PROJECT_BINARY_DIR}/Doxyfile")
-
-  add_dependencies(toolbox-doc toolbox-image)
-endif()
-
 include_directories(SYSTEM
   "${Boost_INCLUDE_DIRS}")
 
@@ -195,10 +181,20 @@ if (CLANG_TIDY)
         -p "${CMAKE_BINARY_DIR}")
 endif()
 
-add_subdirectory(image)
+install(FILES
+  CODE_OF_CONDUCT.md
+  CONTRIBUTING.md
+  LICENSE.md
+  README.md
+  DESTINATION doc
+  COMPONENT doc
+)
+
 add_subdirectory(toolbox)
 add_subdirectory(bench)
 add_subdirectory(example)
+add_subdirectory(image)
+add_subdirectory(doc)
 
 set(CPACK_GENERATOR "TGZ;RPM;DEB")
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,46 @@
+# The Reactive C++ Toolbox.
+# Copyright (C) 2013-2019 Swirly Cloud Limited
+# Copyright (C) 2019 Reactive Markets Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+install(FILES
+  Algorithms.md
+  BuildFromSource.md
+  Concurrency.md
+  DataStructures.md
+  Dependencies.md
+  Messaging.md
+  MoSCoW.md
+  StringHandling.md
+  DESTINATION doc
+  COMPONENT doc
+)
+
+set(doc_DEPENDS)
+
+if(DOXYGEN_FOUND)
+  configure_file(Doxyfile.in "${PROJECT_BINARY_DIR}/doc/Doxyfile" @ONLY)
+
+  add_custom_target(toolbox-doxygen
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    COMMAND "${DOXYGEN_EXECUTABLE}" "${PROJECT_BINARY_DIR}/doc/Doxyfile"
+    COMMAND "${CMAKE_COMMAND}" -E echo docs.toolbox.reactivemarkets.com
+           >"${PROJECT_BINARY_DIR}/doc/html/CNAME"
+    SOURCES "${PROJECT_BINARY_DIR}/doc/Doxyfile")
+
+  add_dependencies(toolbox-doxygen toolbox-image)
+  set(doc_DEPENDS ${doc_DEPENDS} toolbox-doxygen)
+endif()
+
+add_custom_target(toolbox-doc DEPENDS ${doc_DEPENDS})

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.15
+# Doxyfile 1.8.16
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -199,6 +199,16 @@ SHORT_NAMES            = NO
 
 JAVADOC_AUTOBRIEF      = NO
 
+# If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
+# such as
+# /***************
+# as being the beginning of a Javadoc-style comment "banner". If set to NO, the
+# Javadoc-style will behave just like regular comments and it will not be
+# interpreted by doxygen.
+# The default value is: NO.
+
+JAVADOC_BANNER         = NO
+
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
 # set to NO, the Qt-style will behave just like regular Qt-style comments (thus
@@ -331,7 +341,7 @@ MARKDOWN_SUPPORT       = YES
 # to that level are automatically included in the table of contents, even if
 # they do not have an id attribute.
 # Note: This feature currently applies only to Markdown headings.
-# Minimum value: 0, maximum value: 99, default value: 0.
+# Minimum value: 0, maximum value: 99, default value: 5.
 # This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
 
 TOC_INCLUDE_HEADINGS   = 0
@@ -467,6 +477,12 @@ EXTRACT_ALL            = YES
 
 EXTRACT_PRIVATE        = NO
 
+# If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
+# methods of a class will be included in the documentation.
+# The default value is: NO.
+
+EXTRACT_PRIV_VIRTUAL   = NO
+
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.
 # The default value is: NO.
@@ -545,7 +561,7 @@ INTERNAL_DOCS          = NO
 # names in lower-case letters. If set to YES, upper-case letters are also
 # allowed. This is useful if you have classes or files whose names only differ
 # in case and if your file system supports case sensitive file names. Windows
-# and Mac users are advised to set this option to NO.
+# (including Cygwin) ands Mac users are advised to set this option to NO.
 # The default value is: system dependent.
 
 CASE_SENSE_NAMES       = YES
@@ -1374,7 +1390,7 @@ QCH_FILE               =
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
-# (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#namespace).
+# (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#namespace).
 # The default value is: org.doxygen.Project.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1382,7 +1398,7 @@ QHP_NAMESPACE          = org.doxygen.Project
 
 # The QHP_VIRTUAL_FOLDER tag specifies the namespace to use when generating Qt
 # Help Project output. For more information please see Qt Help Project / Virtual
-# Folders (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#virtual-
+# Folders (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#virtual-
 # folders).
 # The default value is: doc.
 # This tag requires that the tag GENERATE_QHP is set to YES.
@@ -1391,7 +1407,7 @@ QHP_VIRTUAL_FOLDER     = doc
 
 # If the QHP_CUST_FILTER_NAME tag is set, it specifies the name of a custom
 # filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
+# Filters (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1399,7 +1415,7 @@ QHP_CUST_FILTER_NAME   =
 
 # The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
 # custom filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
+# Filters (see: https://doc.qt.io/archives/qt-4.8/qthelpproject.html#custom-
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
@@ -1407,7 +1423,7 @@ QHP_CUST_FILTER_ATTRS  =
 
 # The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
 # project's filter section matches. Qt Help Project / Filter Attributes (see:
-# http://doc.qt.io/archives/qt-4.8/qthelpproject.html#filter-attributes).
+# https://doc.qt.io/archives/qt-4.8/qthelpproject.html#filter-attributes).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
 QHP_SECT_FILTER_ATTRS  =
@@ -1686,10 +1702,11 @@ LATEX_CMD_NAME         =
 MAKEINDEX_CMD_NAME     = makeindex
 
 # The LATEX_MAKEINDEX_CMD tag can be used to specify the command name to
-# generate index for LaTeX.
+# generate index for LaTeX. In case there is no backslash (\) as first character
+# it will be automatically added in the LaTeX code.
 # Note: This tag is used in the generated output file (.tex).
 # See also: MAKEINDEX_CMD_NAME for the part in the Makefile / make.bat.
-# The default value is: \makeindex.
+# The default value is: makeindex.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_MAKEINDEX_CMD    = \makeindex
@@ -2181,12 +2198,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2199,15 +2210,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/toolbox/hdr/Histogram.hpp
+++ b/toolbox/hdr/Histogram.hpp
@@ -125,8 +125,6 @@ class TOOLBOX_API HdrHistogram {
     ///
     /// If you want to re-use an existing histogram, but reset everything back to zero, this is the
     /// routine to use.
-    ///
-    /// \param h The histogram you want to reset to empty.
     void reset() noexcept;
 
     /// Records a value in the histogram, will round this value of to a precision at or better than


### PR DESCRIPTION
Move Doxygen target to the doc directory, so that it is more consistent with the downstream Matchbox project and paves the way for additional kinds of documentation.