### PR TITLE
feat(socket): add support for TCP_SYNCNT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,15 @@ function(install_libraries)
   endforeach()
 endfunction()
 
-set(Boost_USE_STATIC_LIBS ON)
+include_directories(
+  "${PROJECT_SOURCE_DIR}"
+  "${CMAKE_BINARY_DIR}/include")
+
+if(NOT TOOLBOX_BUILD_SHARED)
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
 find_package(Boost 1.67 REQUIRED COMPONENTS date_time unit_test_framework)
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 install_libraries("${Boost_DATE_TIME_LIBRARY}")
 
 add_definitions(-DBOOST_NO_AUTO_PTR=1 -DBOOST_NO_RTTI=1 -DBOOST_NO_TYPEID=1)
@@ -132,13 +139,6 @@ if(NOT "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}" MATCHES "\\.a$")
 endif()
 
 find_package(Doxygen) # Optional.
-
-include_directories(SYSTEM
-  "${Boost_INCLUDE_DIRS}")
-
-include_directories(
-  "${PROJECT_SOURCE_DIR}"
-  "${CMAKE_BINARY_DIR}/include")
 
 if(TOOLBOX_BUILD_SHARED)
   set(toolbox_LIBRARY toolbox-shared)

--- a/example/EchoClnt.cpp
+++ b/example/EchoClnt.cpp
@@ -123,7 +123,14 @@ class EchoClnt : public StreamConnector<EchoClnt> {
     }
 
   private:
-    void on_sock_init(CyclTime now, IoSock& sock) {}
+    void on_sock_init(CyclTime now, IoSock& sock)
+    {
+        if (sock.is_ip_family()) {
+            // Set the number of SYN retransmits that TCP should send before aborting the attempt to
+            // connect.
+            set_tcp_syn_nt(sock.get(), 1);
+        }
+    }
     void on_sock_connect(CyclTime now, IoSock&& sock, const Endpoint& ep)
     {
         TOOLBOX_INFO << "connection opened: " << ep;

--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -711,16 +711,58 @@ inline void set_so_snd_buf(int sockfd, int size)
     os::setsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size));
 }
 
+/// Enable or disable the Nagle algorithm.
+///
+/// This means that segments are always sent as soon as possible, even if there is only a small
+/// amount of data. When not set, data is buffered until there is a sufficient amount to send out,
+/// thereby avoiding the frequent sending of small packets, which results in poor utilization of the
+/// network.
+///
+/// \param sockfd The socket descriptor.
+/// \param enabled Boolean switch to enable or disable.
+/// \param ec Error-code set on failure.
 inline void set_tcp_no_delay(int sockfd, bool enabled, std::error_code& ec) noexcept
 {
     int optval{enabled ? 1 : 0};
     os::setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval), ec);
 }
 
+/// Enable or disable the Nagle algorithm.
+///
+/// This means that segments are always sent as soon as possible, even if there is only a small
+/// amount of data. When not set, data is buffered until there is a sufficient amount to send out,
+/// thereby avoiding the frequent sending of small packets, which results in poor utilization of the
+/// network.
+///
+/// \param sockfd The socket descriptor.
+/// \param enabled Boolean switch to enable or disable.
 inline void set_tcp_no_delay(int sockfd, bool enabled)
 {
     int optval{enabled ? 1 : 0};
     os::setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+}
+
+/// Set the number of SYN retransmits that TCP should send before aborting the attempt to connect.
+///
+/// The number of retransmits cannot exceed 255.
+///
+/// \param sockfd The socket descriptor.
+/// \param retrans The number of retransmits.
+/// \param ec Error-code set on failure.
+inline void set_tcp_syn_nt(int sockfd, int retrans, std::error_code& ec) noexcept
+{
+    os::setsockopt(sockfd, IPPROTO_TCP, TCP_SYNCNT, &retrans, sizeof(retrans), ec);
+}
+
+/// Set the number of SYN retransmits that TCP should send before aborting the attempt to connect.
+///
+/// The number of retransmits cannot exceed 255.
+///
+/// \param sockfd The socket descriptor.
+/// \param retrans The number of retransmits.
+inline void set_tcp_syn_nt(int sockfd, int retrans)
+{
+    os::setsockopt(sockfd, IPPROTO_TCP, TCP_SYNCNT, &retrans, sizeof(retrans));
 }
 
 struct Sock {


### PR DESCRIPTION
The TCP_SYNCNT option specifies the number of SYN retransmits that a TCP socket should send before aborting the connection attempt.