### PR TITLE
Reduce context switches

### DIFF
--- a/example/EchoClnt.cpp
+++ b/example/EchoClnt.cpp
@@ -55,7 +55,7 @@ class EchoConn {
     {
         try {
             if (events & (EventIn | EventHup)) {
-                const auto size = os::read(fd, buf_.prepare(2048));
+                const auto size = os::read(fd, buf_.prepare(2944));
                 if (size == 0) {
                     dispose(now);
                     return;

--- a/example/EchoServ.cpp
+++ b/example/EchoServ.cpp
@@ -57,7 +57,7 @@ class EchoConn {
     {
         try {
             if (events & (EventIn | EventHup)) {
-                const auto size = os::read(fd, buf_.prepare(2048));
+                const auto size = os::read(fd, buf_.prepare(2944));
                 if (size == 0) {
                     dispose(now);
                     return;


### PR DESCRIPTION
Rework the I/O event handling on HTTP connections to reduce the number of context switches.