### PR TITLE
Rename create functions

### DIFF
--- a/toolbox/ipc/MpmcQueue.hpp
+++ b/toolbox/ipc/MpmcQueue.hpp
@@ -258,7 +258,7 @@ class MpmcQueue {
 
 /// Initialise file-based MpmcQueue.
 template <typename ValueT>
-void create_mpmc_queue(FileHandle& fh, std::size_t capacity)
+void new_mpmc_queue(FileHandle& fh, std::size_t capacity)
 {
     using Elem = typename MpmcQueue<ValueT>::Elem;
     using Impl = typename MpmcQueue<ValueT>::Impl;
@@ -281,9 +281,9 @@ void create_mpmc_queue(FileHandle& fh, std::size_t capacity)
 
 /// Initialise file-based MpmcQueue.
 template <typename ValueT>
-void create_mpmc_queue(FileHandle&& fh, std::size_t capacity)
+void new_mpmc_queue(FileHandle&& fh, std::size_t capacity)
 {
-    return create_mpmc_queue<ValueT>(fh, capacity);
+    return new_mpmc_queue<ValueT>(fh, capacity);
 }
 
 } // namespace ipc

--- a/toolbox/ipc/Msg.hpp
+++ b/toolbox/ipc/Msg.hpp
@@ -25,14 +25,14 @@ inline namespace ipc {
 using MsgData = char[MaxMsgSize];
 using MsgQueue = MpmcQueue<MsgData>;
 
-inline void create_msg_queue(FileHandle& fh, std::size_t capacity)
+inline void new_msg_queue(FileHandle& fh, std::size_t capacity)
 {
-    create_mpmc_queue<MsgData>(fh, capacity);
+    new_mpmc_queue<MsgData>(fh, capacity);
 }
 
-inline void create_msg_queue(FileHandle&& fh, std::size_t capacity)
+inline void new_msg_queue(FileHandle&& fh, std::size_t capacity)
 {
-    create_mpmc_queue<MsgData>(fh, capacity);
+    new_mpmc_queue<MsgData>(fh, capacity);
 }
 
 } // namespace ipc


### PR DESCRIPTION
Adopt new convention of using new instead of create as the factory function prefix.