### PR TITLE
DEV-2024: update C++ toolchain

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: reactivemarkets/toolchain-cpp:debian
+    container: reactivemarkets/toolchain-cpp:0.2.0
 
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
@@ -40,8 +40,8 @@ jobs:
           mkdir -p build
           cd build
           cmake .. -G "Unix Makefiles" \
-            -DCMAKE_C_COMPILER=gcc-8 \
-            -DCMAKE_CXX_COMPILER=g++-8
+            -DCMAKE_C_COMPILER=gcc-9 \
+            -DCMAKE_CXX_COMPILER=g++-9
 
       - name: Run cppcheck
         run: cd build && make -j2 cppcheck
@@ -53,7 +53,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: reactivemarkets/toolchain-cpp:debian
+    container: reactivemarkets/toolchain-cpp:0.2.0
     needs: lint
 
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
@@ -62,8 +62,8 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         compiler:
-          - {cc: clang-7, cxx: clang++-7}
-          - {cc: gcc-8, cxx: g++-8}
+          - {cc: clang-9, cxx: clang++-9}
+          - {cc: gcc-9, cxx: g++-9}
 
     steps:
       - name: Checkout project

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,13 +23,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: reactivemarkets/toolchain-cpp:debian
+    container: reactivemarkets/toolchain-cpp:0.2.0
 
     strategy:
       matrix:
         build_type: [Release]
         compiler:
-          - {cc: gcc-8, cxx: g++-8}
+          - {cc: gcc-9, cxx: g++-9}
 
     steps:
       - name: Checkout project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    container: reactivemarkets/toolchain-cpp:debian
+    container: reactivemarkets/toolchain-cpp:0.2.0
 
     strategy:
       matrix:
         build_type: [Release]
         compiler:
-          - {cc: gcc-8, cxx: g++-8}
+          - {cc: gcc-9, cxx: g++-9}
 
     steps:
       - name: Checkout project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
 
 set(CMAKE_C_STANDARD 11)
 # Emits -std=gnu++1z on OSX which is not working as expected.
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(COMMON_WARN "-Wall -Werror -Wextra -Wstrict-aliasing=2 -Wno-unused-parameter -Wno-unused-variable")

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is Toolbox?
 
-The Reactive C++ Toolbox is an open source library of C++17 components designed for efficient
+The Reactive C++ Toolbox is an open source library of C++20 components designed for efficient
 aynchronous IO network applications on the Linux platform. Machine architectures currently supported
 are: AMD64, ARM and ARM32.
 
@@ -11,7 +11,7 @@ are: AMD64, ARM and ARM32.
 To build Toolbox from source, you will need:
 
 - [CMake](http://www.cmake.org/) for Makefile generation;
-- [GCC](http://gcc.gnu.org/) or [Clang](http://clang.llvm.org/) with support for C++17;
+- [GCC](http://gcc.gnu.org/) or [Clang](http://clang.llvm.org/) with support for C++20;
 - [Boost](http://www.boost.org/) for additional library dependencies.
 
 ## Getting Started

--- a/etc/cppcheck-suppressions.txt
+++ b/etc/cppcheck-suppressions.txt
@@ -1,7 +1,10 @@
 bufferAccessOutOfBounds:*/toolbox/util/String.ut.cpp
 cppcheckError:*/toolbox/util/IntTypes.ut.cpp
+internalAstError:*/toolbox/io/Disposer.hpp
+internalAstError:*/toolbox/util/VarSub.ut.cpp
 preprocessorErrorDirective:*/toolbox/contrib/robin_hood.h
 preprocessorErrorDirective:*/toolbox/net/Error.cpp
 preprocessorErrorDirective:*/toolbox/sys/Error.cpp
 returnDanglingLifetime:*/toolbox/io/Timer.cpp
 syntaxError:*/toolbox/sys/Thread.cpp
+syntaxError:*/toolbox/util/Variant.hpp

--- a/etc/dotdepend.pl
+++ b/etc/dotdepend.pl
@@ -23,7 +23,7 @@ my $cxx = $ENV{CXX} || 'g++';
 my $lib = shift;
 $lib or die "Library name not specified";
 
-my $makedepend = "$cxx -std=c++17 -MM -MG -I. toolbox/$lib/*.[ch]pp";
+my $makedepend = "$cxx -std=c++2a -MM -MG -I. toolbox/$lib/*.[ch]pp";
 my $tred = 'tred';
 
 sub ltrim {

--- a/toolbox/io/Reactor.hpp
+++ b/toolbox/io/Reactor.hpp
@@ -20,8 +20,8 @@
 #include <toolbox/io/Epoll.hpp>
 #include <toolbox/io/EventFd.hpp>
 #include <toolbox/io/Hook.hpp>
-#include <toolbox/io/Waker.hpp>
 #include <toolbox/io/Timer.hpp>
+#include <toolbox/io/Waker.hpp>
 
 namespace toolbox {
 inline namespace io {


### PR DESCRIPTION
Upgrade toolchain image to Clang and GCC 9.x, so that we can use features from C++20.

DEV-2024