### PR TITLE
fix: code does not compile on Clang v10

### DIFF
--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -34,30 +34,30 @@ void on_bar(const HttpRequest& req, HttpStream& os)
     os << "Hello, Bar!";
 }
 
-class HttpApp : public HttpAppBase {
+class HttpApp final : public HttpAppBase {
   public:
     using Slot = BasicSlot<const HttpRequest&, HttpStream&>;
     using SlotMap = RobinMap<std::string, Slot>;
 
-    ~HttpApp() final = default;
+    ~HttpApp() override = default;
     void bind(const std::string& path, Slot slot) { slot_map_[path] = slot; }
 
   protected:
-    void do_on_http_connect(CyclTime now, const Endpoint& ep) noexcept final
+    void do_on_http_connect(CyclTime now, const Endpoint& ep) noexcept override
     {
         TOOLBOX_INFO << "http session connected: " << ep;
     }
-    void do_on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept final
+    void do_on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept override
     {
         TOOLBOX_INFO << "http session disconnected: " << ep;
     }
     void do_on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                          HttpStream& os) noexcept final
+                          HttpStream& os) noexcept override
     {
         TOOLBOX_ERROR << "http session error: " << ep << ": " << e.what();
     }
     void do_on_http_message(CyclTime now, const Endpoint& ep, const HttpRequest& req,
-                            HttpStream& os) final
+                            HttpStream& os) override
     {
         const auto it = slot_map_.find(string{req.path()});
         if (it != slot_map_.end()) {
@@ -69,7 +69,7 @@ class HttpApp : public HttpAppBase {
         }
         os.commit();
     }
-    void do_on_http_timeout(CyclTime now, const Endpoint& ep) noexcept final
+    void do_on_http_timeout(CyclTime now, const Endpoint& ep) noexcept override
     {
         TOOLBOX_WARNING << "http session timeout: " << ep;
     }

--- a/toolbox/hdr/Iterator.hpp
+++ b/toolbox/hdr/Iterator.hpp
@@ -84,10 +84,10 @@ class TOOLBOX_API HdrIterator {
 };
 
 /// HdrPercentileIterator is a percentile iterator.
-class TOOLBOX_API HdrPercentileIterator : public HdrIterator {
+class TOOLBOX_API HdrPercentileIterator final : public HdrIterator {
   public:
     HdrPercentileIterator(const HdrHistogram& h, std::int32_t ticks_per_half_distance) noexcept;
-    ~HdrPercentileIterator() final = default;
+    ~HdrPercentileIterator() override = default;
 
     // Copy.
     HdrPercentileIterator(const HdrPercentileIterator&) = delete;
@@ -100,7 +100,7 @@ class TOOLBOX_API HdrPercentileIterator : public HdrIterator {
     double percentile() const noexcept { return percentile_; }
 
   protected:
-    bool do_next() noexcept final;
+    bool do_next() noexcept override;
 
   private:
     bool seen_last_value_;
@@ -133,10 +133,10 @@ class TOOLBOX_API HdrCountAddedIterator : public HdrIterator {
 };
 
 /// HdrRecordedIterator is a recorded value iterator.
-class TOOLBOX_API HdrRecordedIterator : public HdrCountAddedIterator {
+class TOOLBOX_API HdrRecordedIterator final : public HdrCountAddedIterator {
   public:
     HdrRecordedIterator(const HdrHistogram& h);
-    ~HdrRecordedIterator() final = default;
+    ~HdrRecordedIterator() override = default;
 
     // Copy.
     HdrRecordedIterator(const HdrRecordedIterator&) = delete;
@@ -147,14 +147,14 @@ class TOOLBOX_API HdrRecordedIterator : public HdrCountAddedIterator {
     HdrRecordedIterator& operator=(HdrRecordedIterator&&) = delete;
 
   protected:
-    bool do_next() noexcept final;
+    bool do_next() noexcept override;
 };
 
 /// HdrLinearIterator is a linear value iterator.
-class TOOLBOX_API HdrLinearIterator : public HdrCountAddedIterator {
+class TOOLBOX_API HdrLinearIterator final : public HdrCountAddedIterator {
   public:
     HdrLinearIterator(const HdrHistogram& h, std::int64_t value_units_per_bucket) noexcept;
-    ~HdrLinearIterator() final = default;
+    ~HdrLinearIterator() override = default;
 
     // Copy.
     HdrLinearIterator(const HdrLinearIterator&) = delete;
@@ -165,7 +165,7 @@ class TOOLBOX_API HdrLinearIterator : public HdrCountAddedIterator {
     HdrLinearIterator& operator=(HdrLinearIterator&&) = delete;
 
   protected:
-    bool do_next() noexcept final;
+    bool do_next() noexcept override;
 
   private:
     std::int64_t value_units_per_bucket_;
@@ -174,11 +174,11 @@ class TOOLBOX_API HdrLinearIterator : public HdrCountAddedIterator {
 };
 
 /// HdrLogIterator is a logarithmic value iterator.
-class TOOLBOX_API HdrLogIterator : public HdrCountAddedIterator {
+class TOOLBOX_API HdrLogIterator final : public HdrCountAddedIterator {
   public:
     HdrLogIterator(const HdrHistogram& h, std::int64_t value_units_first_bucket,
                    double log_base) noexcept;
-    ~HdrLogIterator() final = default;
+    ~HdrLogIterator() override = default;
 
     // Copy.
     HdrLogIterator(const HdrLogIterator&) = delete;
@@ -189,7 +189,7 @@ class TOOLBOX_API HdrLogIterator : public HdrCountAddedIterator {
     HdrLogIterator& operator=(HdrLogIterator&&) = delete;
 
   protected:
-    bool do_next() noexcept final;
+    bool do_next() noexcept override;
 
   private:
     double log_base_;

--- a/toolbox/http/Error.cpp
+++ b/toolbox/http/Error.cpp
@@ -20,9 +20,9 @@ namespace toolbox {
 using namespace std::literals::string_literals;
 inline namespace http {
 namespace {
-struct HttpErrorCategory : std::error_category {
+struct HttpErrorCategory final : std::error_category {
     constexpr HttpErrorCategory() noexcept = default;
-    ~HttpErrorCategory() final = default;
+    ~HttpErrorCategory() override = default;
 
     // Copy.
     HttpErrorCategory(const HttpErrorCategory&) = delete;
@@ -32,8 +32,11 @@ struct HttpErrorCategory : std::error_category {
     HttpErrorCategory(HttpErrorCategory&&) = delete;
     HttpErrorCategory& operator=(HttpErrorCategory&&) = delete;
 
-    const char* name() const noexcept final { return "http"; }
-    std::string message(int err) const final { return enum_string(static_cast<HttpStatus>(err)); }
+    const char* name() const noexcept override { return "http"; }
+    std::string message(int err) const override
+    {
+        return enum_string(static_cast<HttpStatus>(err));
+    }
 };
 
 const HttpErrorCategory ecat_{};

--- a/toolbox/http/Stream.hpp
+++ b/toolbox/http/Stream.hpp
@@ -28,13 +28,13 @@ constexpr char ApplicationJson[]{"application/json"};
 constexpr char TextHtml[]{"text/html"};
 constexpr char TextPlain[]{"text/plain"};
 
-class TOOLBOX_API HttpBuf : public std::streambuf {
+class TOOLBOX_API HttpBuf final : public std::streambuf {
   public:
     explicit HttpBuf(Buffer& buf) noexcept
     : buf_{buf}
     {
     }
-    ~HttpBuf() final;
+    ~HttpBuf() override;
 
     // Copy.
     HttpBuf(const HttpBuf&) = delete;
@@ -54,8 +54,8 @@ class TOOLBOX_API HttpBuf : public std::streambuf {
     void set_content_length(std::streamsize pos, std::streamsize len) noexcept;
 
   protected:
-    int_type overflow(int_type c) noexcept final;
-    std::streamsize xsputn(const char_type* s, std::streamsize count) noexcept final;
+    int_type overflow(int_type c) noexcept override;
+    std::streamsize xsputn(const char_type* s, std::streamsize count) noexcept override;
 
   private:
     Buffer& buf_;
@@ -63,7 +63,7 @@ class TOOLBOX_API HttpBuf : public std::streambuf {
     std::streamsize pcount_{0};
 };
 
-class TOOLBOX_API HttpStream : public std::ostream {
+class TOOLBOX_API HttpStream final : public std::ostream {
   public:
     explicit HttpStream(Buffer& buf) noexcept
     : std::ostream{nullptr}
@@ -71,7 +71,7 @@ class TOOLBOX_API HttpStream : public std::ostream {
     {
         rdbuf(&buf_);
     }
-    ~HttpStream() final;
+    ~HttpStream() override;
 
     // Copy.
     HttpStream(const HttpStream&) = delete;

--- a/toolbox/net/Error.cpp
+++ b/toolbox/net/Error.cpp
@@ -27,9 +27,9 @@
 namespace toolbox {
 inline namespace net {
 namespace {
-struct GaiErrorCategory : std::error_category {
+struct GaiErrorCategory final : std::error_category {
     constexpr GaiErrorCategory() noexcept = default;
-    ~GaiErrorCategory() final = default;
+    ~GaiErrorCategory() override = default;
 
     // Copy.
     GaiErrorCategory(const GaiErrorCategory&) = delete;
@@ -39,8 +39,8 @@ struct GaiErrorCategory : std::error_category {
     GaiErrorCategory(GaiErrorCategory&&) = delete;
     GaiErrorCategory& operator=(GaiErrorCategory&&) = delete;
 
-    const char* name() const noexcept final { return "gai"; }
-    std::string message(int err) const final { return gai_strerror(err); }
+    const char* name() const noexcept override { return "gai"; }
+    std::string message(int err) const override { return gai_strerror(err); }
 };
 
 const GaiErrorCategory gai_cat_{};

--- a/toolbox/util/Ryu.ut.cpp
+++ b/toolbox/util/Ryu.ut.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(RyuFixedCase)
     BOOST_TEST(dtofixed(1e6) == "1000000"sv);
     BOOST_TEST(dtofixed(-1e6) == "-1000000"sv);
     BOOST_TEST(dtofixed(1.0 / 0.0) == "Infinity"sv);
-    BOOST_TEST(dtofixed(std::numeric_limits<std::int64_t>::max() * 10.0)
+    BOOST_TEST(dtofixed(static_cast<double>(std::numeric_limits<std::int64_t>::max()) * 10.0)
                == "92233720368547758080"sv);
     BOOST_TEST(dtofixed(std::numeric_limits<std::int64_t>::min() * 10.0)
                == "-92233720368547758080"sv);

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -30,10 +30,10 @@ inline namespace util {
 TOOLBOX_API void reset(std::ostream& os) noexcept;
 
 template <std::size_t MaxN>
-class StaticBuf : public std::streambuf {
+class StaticBuf final : public std::streambuf {
   public:
     StaticBuf() noexcept { reset(); }
-    ~StaticBuf() final = default;
+    ~StaticBuf() override = default;
 
     // Copy.
     StaticBuf(const StaticBuf&) = delete;
@@ -54,14 +54,14 @@ class StaticBuf : public std::streambuf {
 };
 
 template <std::size_t MaxN>
-class StaticStream : public std::ostream {
+class StaticStream final : public std::ostream {
   public:
     StaticStream()
     : std::ostream{nullptr}
     {
         rdbuf(&buf_);
     }
-    ~StaticStream() final = default;
+    ~StaticStream() override = default;
 
     // Copy.
     StaticStream(const StaticStream&) = delete;


### PR DESCRIPTION
Code does not compile on Clang v10 due to a number of pedantic warnings. (We treat warnings as errors.)

DEV-2162