### PR TITLE
Update usage of cppcheck

### DIFF
--- a/cppcheck.sh.in
+++ b/cppcheck.sh.in
@@ -28,7 +28,7 @@
 errors=$("@CPPCHECK@" -j @CORE_COUNT@ \
                        --project="@CMAKE_BINARY_DIR@/compile_commands.json" \
                        --quiet \
-                       --std=c++14 \
+                       --std=c++20 \
                        --suppressions-list="@CMAKE_SOURCE_DIR@/etc/cppcheck-suppressions.txt" \
                        -DBOOST_AUTO_TEST_SUITE \
                        -DTOOLBOX_BENCHMARK \

--- a/etc/cppcheck-suppressions.txt
+++ b/etc/cppcheck-suppressions.txt
@@ -1,10 +1,6 @@
 bufferAccessOutOfBounds:*/toolbox/util/String.ut.cpp
-cppcheckError:*/toolbox/util/IntTypes.ut.cpp
 internalAstError:*/toolbox/io/Disposer.hpp
-internalAstError:*/toolbox/util/VarSub.ut.cpp
 preprocessorErrorDirective:*/toolbox/contrib/robin_hood.h
 preprocessorErrorDirective:*/toolbox/net/Error.cpp
-preprocessorErrorDirective:*/toolbox/sys/Error.cpp
 returnDanglingLifetime:*/toolbox/io/Timer.cpp
-syntaxError:*/toolbox/sys/Thread.cpp
 syntaxError:*/toolbox/util/Variant.hpp


### PR DESCRIPTION
Update usage of cppcheck. Switch to C++20 and remove fixed suppressions.

Closes #89