### PR TITLE
feat: reset resolver before running

### DIFF
--- a/toolbox/net/Resolver.cpp
+++ b/toolbox/net/Resolver.cpp
@@ -70,6 +70,12 @@ void Resolver::clear()
     return queue_.clear();
 }
 
+void Resolver::reset()
+{
+    Lock lock{mutex_};
+    stop_ = false;
+}
+
 AddrInfoFuture Resolver::resolve(const std::string& uri, int type)
 {
     Task task{[=]() -> AddrInfoPtr { return parse_endpoint(uri, type); }};

--- a/toolbox/net/Resolver.hpp
+++ b/toolbox/net/Resolver.hpp
@@ -59,6 +59,9 @@ class TOOLBOX_API Resolver {
     /// Clear task queue. Any pending tasks will be cancelled, resulting in a broken promise.
     void clear();
 
+    /// Reset resolver state.
+    void reset();
+
     /// Schedule a URI socket name resolution.
     AddrInfoFuture resolve(const std::string& uri, int type);
 

--- a/toolbox/net/Runner.cpp
+++ b/toolbox/net/Runner.cpp
@@ -18,8 +18,6 @@
 
 #include "Resolver.hpp"
 
-#include <toolbox/io/Reactor.hpp>
-
 #include <toolbox/sys/Log.hpp>
 #include <toolbox/sys/Signal.hpp>
 
@@ -32,6 +30,8 @@ void run_resolver(Resolver& r, ThreadConfig config)
     try {
         set_thread_attrs(config);
         TOOLBOX_NOTICE << "started " << config.name << " thread";
+        // Reset the resolver before entering the run loop.
+        r.reset();
         // The run() function returns -1 when resolver is closed.
         while (r.run() >= 0)
             ;


### PR DESCRIPTION
Add a reset method to the resolver, so that a single instance can be reset and reused multiple times. This is required for downstream Python bindings.

DEV-2226