### PR TITLE
refactor: rename HttpAppBase to HttpApp

### DIFF
--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -34,12 +34,12 @@ void on_bar(const HttpRequest& req, HttpStream& os)
     os << "Hello, Bar!";
 }
 
-class HttpApp final : public HttpAppBase {
+class ExampleApp final : public HttpApp {
   public:
     using Slot = BasicSlot<const HttpRequest&, HttpStream&>;
     using SlotMap = RobinMap<std::string, Slot>;
 
-    ~HttpApp() override = default;
+    ~ExampleApp() override = default;
     void bind(const std::string& path, Slot slot) { slot_map_[path] = slot; }
 
   protected:
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
         const auto start_time = CyclTime::now();
 
         Reactor reactor{1024};
-        HttpApp app;
+        ExampleApp app;
         app.bind("/foo", bind<on_foo>());
         app.bind("/bar", bind<on_bar>());
 

--- a/toolbox/http/App.cpp
+++ b/toolbox/http/App.cpp
@@ -19,7 +19,7 @@
 namespace toolbox {
 inline namespace http {
 
-HttpAppBase::~HttpAppBase() = default;
+HttpApp::~HttpApp() = default;
 
 } // namespace http
 } // namespace toolbox

--- a/toolbox/http/App.hpp
+++ b/toolbox/http/App.hpp
@@ -27,21 +27,21 @@ inline namespace http {
 class HttpRequest;
 class HttpStream;
 
-class TOOLBOX_API HttpAppBase {
+class TOOLBOX_API HttpApp {
   public:
     using Protocol = StreamProtocol;
     using Endpoint = StreamEndpoint;
 
-    HttpAppBase() noexcept = default;
-    virtual ~HttpAppBase();
+    HttpApp() noexcept = default;
+    virtual ~HttpApp();
 
     // Copy.
-    constexpr HttpAppBase(const HttpAppBase&) noexcept = default;
-    HttpAppBase& operator=(const HttpAppBase&) noexcept = default;
+    constexpr HttpApp(const HttpApp&) noexcept = default;
+    HttpApp& operator=(const HttpApp&) noexcept = default;
 
     // Move.
-    constexpr HttpAppBase(HttpAppBase&&) noexcept = default;
-    HttpAppBase& operator=(HttpAppBase&&) noexcept = default;
+    constexpr HttpApp(HttpApp&&) noexcept = default;
+    HttpApp& operator=(HttpApp&&) noexcept = default;
 
     void on_http_connect(CyclTime now, const Endpoint& ep) { do_on_http_connect(now, ep); }
     void on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept

--- a/toolbox/http/Conn.hpp
+++ b/toolbox/http/Conn.hpp
@@ -31,7 +31,7 @@
 
 namespace toolbox {
 inline namespace http {
-class HttpAppBase;
+class HttpApp;
 
 template <typename RequestT, typename AppT>
 class BasicHttpConn
@@ -278,7 +278,7 @@ class BasicHttpConn
     bool in_progress_{false}, write_blocked_{false};
 };
 
-using HttpConn = BasicHttpConn<HttpRequest, HttpAppBase>;
+using HttpConn = BasicHttpConn<HttpRequest, HttpApp>;
 
 } // namespace http
 } // namespace toolbox

--- a/toolbox/http/Serv.hpp
+++ b/toolbox/http/Serv.hpp
@@ -73,7 +73,7 @@ class BasicHttpServ : public StreamAcceptor<BasicHttpServ<ConnT, AppT>> {
     ConnList conn_list_;
 };
 
-using HttpServ = BasicHttpServ<HttpConn, HttpAppBase>;
+using HttpServ = BasicHttpServ<HttpConn, HttpApp>;
 
 } // namespace http
 } // namespace toolbox


### PR DESCRIPTION
Drop the "Base" suffix from HttpAppBase, because this is the only class type in this project that follows this convention.