### PR TITLE
refactor: avoid namespace names as type prefixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ $ make clang-format
 - types and integer constants start with an upper-case character;
 - trailing underscore for private data-members.
 
+Namespaces can be used to disambiguate conflicting type names, so there is no need to prefix type
+names with the namespace name. The HTTP server in the http namespace, for example, is called Serv,
+not HttpServ.
+
 ### Class Layout
 
 The `public` section is first, followed by `protected` and then `private`. Within each section,

--- a/toolbox/Config.h.in
+++ b/toolbox/Config.h.in
@@ -39,13 +39,15 @@
 #define TOOLBOX_API __attribute__((visibility("default")))
 
 /**
- * True if debug build is enabled.
- */
-#define TOOLBOX_BUILD_DEBUG @TOOLBOX_BUILD_DEBUG@
-
-/**
  * True if SystemTap support is enabled.
  */
 #define TOOLBOX_HAVE_SYSTEMTAP @TOOLBOX_HAVE_SYSTEMTAP@
+
+/**
+ * True if debug build is enabled.
+ */
+#ifndef TOOLBOX_BUILD_DEBUG
+#define TOOLBOX_BUILD_DEBUG @TOOLBOX_BUILD_DEBUG@
+#endif
 
 #endif // TOOLBOX_CONFIG_H

--- a/toolbox/bm/Ctx.hpp
+++ b/toolbox/bm/Ctx.hpp
@@ -25,7 +25,7 @@ namespace toolbox::bm {
 
 class TOOLBOX_API BenchmarkCtx {
   public:
-    explicit BenchmarkCtx(HdrHistogram& hist)
+    explicit BenchmarkCtx(Histogram& hist)
     : hist_{hist}
     {
     }
@@ -46,7 +46,7 @@ class TOOLBOX_API BenchmarkCtx {
     void stop() noexcept { stop_ = true; }
 
   private:
-    HdrHistogram& hist_;
+    Histogram& hist_;
     std::atomic_bool stop_{false};
 };
 

--- a/toolbox/bm/Range.cpp
+++ b/toolbox/bm/Range.cpp
@@ -22,7 +22,7 @@
 namespace toolbox::bm {
 using namespace std;
 
-BenchmarkRange::BenchmarkRange(HdrHistogram& hist, int first, int last) noexcept
+BenchmarkRange::BenchmarkRange(Histogram& hist, int first, int last) noexcept
 : hist_{hist}
 , first_{first}
 , last_{last}

--- a/toolbox/bm/Range.hpp
+++ b/toolbox/bm/Range.hpp
@@ -22,7 +22,7 @@
 
 namespace toolbox {
 inline namespace hdr {
-class HdrHistogram;
+class Histogram;
 } // namespace hdr
 } // namespace toolbox
 
@@ -30,7 +30,7 @@ namespace toolbox::bm {
 
 /// The BenchmarkRange class records the time elapsed during object lifetime,
 /// i.e., between construction and destruction.
-/// The elapsed time is recorded in the HdrHistogram object during destruction.
+/// The elapsed time is recorded in the Histogram object during destruction.
 class TOOLBOX_API BenchmarkRange {
     class Iterator {
         friend constexpr bool operator==(Iterator lhs, Iterator rhs) noexcept
@@ -59,7 +59,7 @@ class TOOLBOX_API BenchmarkRange {
     };
 
   public:
-    BenchmarkRange(HdrHistogram& hist, int first, int last) noexcept;
+    BenchmarkRange(Histogram& hist, int first, int last) noexcept;
     ~BenchmarkRange();
 
     // Copy.
@@ -74,7 +74,7 @@ class TOOLBOX_API BenchmarkRange {
     auto end() const noexcept { return Iterator{last_}; }
 
   private:
-    HdrHistogram& hist_;
+    Histogram& hist_;
     const int first_;
     const int last_;
     std::chrono::time_point<std::chrono::high_resolution_clock> start_;

--- a/toolbox/bm/Record.cpp
+++ b/toolbox/bm/Record.cpp
@@ -22,7 +22,7 @@
 namespace toolbox::bm {
 using namespace std;
 
-BenchmarkRecord::BenchmarkRecord(HdrHistogram& hist, int count) noexcept
+BenchmarkRecord::BenchmarkRecord(Histogram& hist, int count) noexcept
 : hist_{hist}
 , count_{count}
 , start_{chrono::high_resolution_clock::now()}

--- a/toolbox/bm/Record.hpp
+++ b/toolbox/bm/Record.hpp
@@ -22,7 +22,7 @@
 
 namespace toolbox {
 inline namespace hdr {
-class HdrHistogram;
+class Histogram;
 } // namespace hdr
 } // namespace toolbox
 
@@ -30,10 +30,10 @@ namespace toolbox::bm {
 
 /// The BenchmarkRecord class records the time elapsed during object lifetime,
 /// i.e., between construction and destruction.
-/// The elapsed time is recorded in the HdrHistogram object during destruction.
+/// The elapsed time is recorded in the Histogram object during destruction.
 class TOOLBOX_API BenchmarkRecord {
   public:
-    BenchmarkRecord(HdrHistogram& hist, int count = 1) noexcept;
+    BenchmarkRecord(Histogram& hist, int count = 1) noexcept;
     ~BenchmarkRecord();
 
     // Copy.
@@ -45,7 +45,7 @@ class TOOLBOX_API BenchmarkRecord {
     BenchmarkRecord& operator=(BenchmarkRecord&&) = delete;
 
   private:
-    HdrHistogram& hist_;
+    Histogram& hist_;
     const int count_;
     std::chrono::time_point<std::chrono::high_resolution_clock> start_;
 };

--- a/toolbox/bm/Suite.cpp
+++ b/toolbox/bm/Suite.cpp
@@ -46,7 +46,7 @@ BenchmarkSuite::BenchmarkSuite(std::ostream& os, double value_scale)
     os << setw(120) << setfill('-') << '-' << setfill(' ') << endl;
 }
 
-void BenchmarkSuite::report(const char* name, HdrHistogram& h)
+void BenchmarkSuite::report(const char* name, Histogram& h)
 {
     boost::io::ios_all_saver all_saver{os_};
 

--- a/toolbox/bm/Suite.hpp
+++ b/toolbox/bm/Suite.hpp
@@ -32,13 +32,13 @@ class TOOLBOX_API BenchmarkSuite {
         using namespace std::literals::chrono_literals;
         constexpr auto duration = 3s;
 
-        HdrHistogram hist{1, 1'000'000'000, 5};
+        Histogram hist{1, 1'000'000'000, 5};
         BenchmarkCtx ctx{hist};
         Alarm alarm{duration, [&ctx]() { ctx.stop(); }};
         fn(ctx);
         report(name, hist);
     }
-    void report(const char* name, HdrHistogram& hist);
+    void report(const char* name, Histogram& hist);
 
   private:
     std::ostream& os_;

--- a/toolbox/hdr/Histogram.hpp
+++ b/toolbox/hdr/Histogram.hpp
@@ -24,8 +24,8 @@ namespace toolbox {
 /// A C++ port of HdrHistogram_c written Michael Barker and released to the public domain.
 inline namespace hdr {
 /// Bucket configuration.
-struct TOOLBOX_API HdrBucketConfig {
-    /// Construct HdrBucketConfig.
+struct TOOLBOX_API BucketConfig {
+    /// Construct BucketConfig.
     ///
     /// Due to the size of the histogram being the result of some reasonably involved math on the
     /// input parameters.
@@ -36,16 +36,16 @@ struct TOOLBOX_API HdrBucketConfig {
     /// figures in a decimal number that will be maintained. E.g. a value of 3 will mean the results
     /// from the histogram will be accurate up to the first three digits. Must be a value between 1
     /// and 5 (inclusive).
-    HdrBucketConfig(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
-                    int significant_figures);
+    BucketConfig(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
+                 int significant_figures);
 
     // Copy.
-    HdrBucketConfig(const HdrBucketConfig&) noexcept = default;
-    HdrBucketConfig& operator=(const HdrBucketConfig&) noexcept = default;
+    BucketConfig(const BucketConfig&) noexcept = default;
+    BucketConfig& operator=(const BucketConfig&) noexcept = default;
 
     // Move.
-    HdrBucketConfig(HdrBucketConfig&&) noexcept = default;
-    HdrBucketConfig& operator=(HdrBucketConfig&&) noexcept = default;
+    BucketConfig(BucketConfig&&) noexcept = default;
+    BucketConfig& operator=(BucketConfig&&) noexcept = default;
 
     std::int64_t lowest_trackable_value;
     std::int64_t highest_trackable_value;
@@ -60,19 +60,19 @@ struct TOOLBOX_API HdrBucketConfig {
 };
 
 /// A High Dynamic Range (HDR) Histogram.
-class TOOLBOX_API HdrHistogram {
+class TOOLBOX_API Histogram {
   public:
-    HdrHistogram(const HdrBucketConfig& config);
-    HdrHistogram(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
-                 std::int32_t significant_figures);
+    Histogram(const BucketConfig& config);
+    Histogram(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
+              std::int32_t significant_figures);
 
     // Copy.
-    HdrHistogram(const HdrHistogram&) = default;
-    HdrHistogram& operator=(const HdrHistogram&) = default;
+    Histogram(const Histogram&) = default;
+    Histogram& operator=(const Histogram&) = default;
 
     // Move.
-    HdrHistogram(HdrHistogram&&) noexcept = default;
-    HdrHistogram& operator=(HdrHistogram&&) noexcept = default;
+    Histogram(Histogram&&) noexcept = default;
+    Histogram& operator=(Histogram&&) noexcept = default;
 
     std::int64_t lowest_trackable_value() const noexcept { return lowest_trackable_value_; }
     std::int64_t highest_trackable_value() const noexcept { return highest_trackable_value_; }

--- a/toolbox/hdr/Histogram.ut.cpp
+++ b/toolbox/hdr/Histogram.ut.cpp
@@ -32,7 +32,7 @@ constexpr auto Bitness = 64;
 
 BOOST_AUTO_TEST_CASE(HistogramBasicCase)
 {
-    HdrHistogram h{Lowest, Highest, Significant};
+    Histogram h{Lowest, Highest, Significant};
     const auto expected_bucket_count = Bitness == 64 ? 22 : 21;
     const auto expected_counts_len = Bitness == 64 ? 23552 : 22528;
 
@@ -46,14 +46,14 @@ BOOST_AUTO_TEST_CASE(HistogramBasicCase)
 
 BOOST_AUTO_TEST_CASE(HistogramEmptyCase)
 {
-    HdrHistogram h{1, 100000000, 1};
+    Histogram h{1, 100000000, 1};
     BOOST_TEST(h.min() == numeric_limits<int64_t>::max());
     BOOST_TEST(h.max() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(HistogramRecordValueCase)
 {
-    HdrHistogram h{Lowest, Highest, Significant};
+    Histogram h{Lowest, Highest, Significant};
     h.record_value(TestValueLevel);
     BOOST_TEST(h.count_at_value(TestValueLevel) == 1);
     BOOST_TEST(h.total_count() == 1);
@@ -61,27 +61,27 @@ BOOST_AUTO_TEST_CASE(HistogramRecordValueCase)
 
 BOOST_AUTO_TEST_CASE(HistogramInvalidSigFigCase)
 {
-    BOOST_CHECK_THROW(HdrHistogram(1, 36000000, -1), invalid_argument);
-    BOOST_CHECK_THROW(HdrHistogram(1, 36000000, 0), invalid_argument);
-    BOOST_CHECK_THROW(HdrHistogram(1, 36000000, 6), invalid_argument);
+    BOOST_CHECK_THROW(Histogram(1, 36000000, -1), invalid_argument);
+    BOOST_CHECK_THROW(Histogram(1, 36000000, 0), invalid_argument);
+    BOOST_CHECK_THROW(Histogram(1, 36000000, 6), invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(HistogramInvalidInitCase)
 {
-    BOOST_CHECK_THROW(HdrHistogram(0, 64 * 1024, 2), invalid_argument);
-    BOOST_CHECK_THROW(HdrHistogram(80, 110, 5), invalid_argument);
+    BOOST_CHECK_THROW(Histogram(0, 64 * 1024, 2), invalid_argument);
+    BOOST_CHECK_THROW(Histogram(80, 110, 5), invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(HistogramOutOfRangeCase)
 {
-    HdrHistogram h{1, 1000, 4};
+    Histogram h{1, 1000, 4};
     BOOST_TEST(h.record_value(32767));
     BOOST_TEST(!h.record_value(32768));
 }
 
 BOOST_AUTO_TEST_CASE(HistogramResetCase)
 {
-    HdrHistogram h{1, 10000000, 3};
+    Histogram h{1, 10000000, 3};
     for (int i{0}; i < 1000; ++i) {
         BOOST_TEST(h.record_value(i));
     }
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(HistogramResetCase)
 
 BOOST_AUTO_TEST_CASE(HistogramTotalCountCase)
 {
-    HdrHistogram h{1, 10000000, 3};
+    Histogram h{1, 10000000, 3};
     for (int i{0}; i < 1000; ++i) {
         BOOST_TEST(h.record_value(i));
         BOOST_TEST(h.total_count() == i + 1);
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(HistogramTotalCountCase)
 
 BOOST_AUTO_TEST_CASE(HistogramRecordEquivalentValueCase)
 {
-    HdrHistogram h{Lowest, Highest, Significant};
+    Histogram h{Lowest, Highest, Significant};
     BOOST_TEST(8183 * 1024 + 1023 == h.highest_equivalent_value(8180 * 1024));
     BOOST_TEST(8191 * 1024 + 1023 == h.highest_equivalent_value(8191 * 1024));
     BOOST_TEST(8199 * 1024 + 1023 == h.highest_equivalent_value(8193 * 1024));

--- a/toolbox/hdr/Iterator.hpp
+++ b/toolbox/hdr/Iterator.hpp
@@ -22,24 +22,24 @@
 namespace toolbox {
 /// A C++ port of HdrHistogram_c written Michael Barker and released to the public domain.
 inline namespace hdr {
-class HdrHistogram;
+class Histogram;
 
-/// HdrIterator is the base iterator for all iterator types.
-class TOOLBOX_API HdrIterator {
+/// Iterator is the base iterator for all iterator types.
+class TOOLBOX_API Iterator {
   public:
     /// Construct iterator.
     ///
     /// \param h The histogram to iterate over.
-    HdrIterator(const HdrHistogram& h) noexcept;
-    virtual ~HdrIterator();
+    Iterator(const Histogram& h) noexcept;
+    virtual ~Iterator();
 
     // Copy.
-    HdrIterator(const HdrIterator&) = delete;
-    HdrIterator& operator=(const HdrIterator&) = delete;
+    Iterator(const Iterator&) = delete;
+    Iterator& operator=(const Iterator&) = delete;
 
     // Move.
-    HdrIterator(HdrIterator&&) noexcept = default;
-    HdrIterator& operator=(HdrIterator&&) = delete;
+    Iterator(Iterator&&) noexcept = default;
+    Iterator& operator=(Iterator&&) = delete;
 
     /// Value directly from array for the current counts_index.
     std::int64_t count() const noexcept { return count_; }
@@ -68,7 +68,7 @@ class TOOLBOX_API HdrIterator {
 
     virtual bool do_next() noexcept;
 
-    const HdrHistogram& h_;
+    const Histogram& h_;
     /// Raw index into the counts array.
     std::int32_t counts_index_;
     /// Snapshot of the length at the time the iterator is created.
@@ -83,19 +83,19 @@ class TOOLBOX_API HdrIterator {
     std::int64_t value_iterated_to_;
 };
 
-/// HdrPercentileIterator is a percentile iterator.
-class TOOLBOX_API HdrPercentileIterator final : public HdrIterator {
+/// PercentileIterator is a percentile iterator.
+class TOOLBOX_API PercentileIterator final : public Iterator {
   public:
-    HdrPercentileIterator(const HdrHistogram& h, std::int32_t ticks_per_half_distance) noexcept;
-    ~HdrPercentileIterator() override = default;
+    PercentileIterator(const Histogram& h, std::int32_t ticks_per_half_distance) noexcept;
+    ~PercentileIterator() override = default;
 
     // Copy.
-    HdrPercentileIterator(const HdrPercentileIterator&) = delete;
-    HdrPercentileIterator& operator=(const HdrPercentileIterator&) = delete;
+    PercentileIterator(const PercentileIterator&) = delete;
+    PercentileIterator& operator=(const PercentileIterator&) = delete;
 
     // Move.
-    HdrPercentileIterator(HdrPercentileIterator&&) noexcept = default;
-    HdrPercentileIterator& operator=(HdrPercentileIterator&&) = delete;
+    PercentileIterator(PercentileIterator&&) noexcept = default;
+    PercentileIterator& operator=(PercentileIterator&&) = delete;
 
     double percentile() const noexcept { return percentile_; }
 
@@ -109,16 +109,16 @@ class TOOLBOX_API HdrPercentileIterator final : public HdrIterator {
     double percentile_;
 };
 
-/// HdrCountAddedIterator is a recorded value iterator.
-class TOOLBOX_API HdrCountAddedIterator : public HdrIterator {
+/// CountAddedIterator is a recorded value iterator.
+class TOOLBOX_API CountAddedIterator : public Iterator {
   public:
     // Copy.
-    HdrCountAddedIterator(const HdrCountAddedIterator&) = delete;
-    HdrCountAddedIterator& operator=(const HdrCountAddedIterator&) = delete;
+    CountAddedIterator(const CountAddedIterator&) = delete;
+    CountAddedIterator& operator=(const CountAddedIterator&) = delete;
 
     // Move.
-    HdrCountAddedIterator(HdrCountAddedIterator&&) noexcept = default;
-    HdrCountAddedIterator& operator=(HdrCountAddedIterator&&) = delete;
+    CountAddedIterator(CountAddedIterator&&) noexcept = default;
+    CountAddedIterator& operator=(CountAddedIterator&&) = delete;
 
     std::int64_t count_added_in_this_iteration_step() const noexcept
     {
@@ -126,43 +126,43 @@ class TOOLBOX_API HdrCountAddedIterator : public HdrIterator {
     }
 
   protected:
-    explicit HdrCountAddedIterator(const HdrHistogram& h);
-    ~HdrCountAddedIterator() override;
+    explicit CountAddedIterator(const Histogram& h);
+    ~CountAddedIterator() override;
 
     std::int64_t count_added_in_this_iteration_step_{0};
 };
 
-/// HdrRecordedIterator is a recorded value iterator.
-class TOOLBOX_API HdrRecordedIterator final : public HdrCountAddedIterator {
+/// RecordedIterator is a recorded value iterator.
+class TOOLBOX_API RecordedIterator final : public CountAddedIterator {
   public:
-    HdrRecordedIterator(const HdrHistogram& h);
-    ~HdrRecordedIterator() override = default;
+    RecordedIterator(const Histogram& h);
+    ~RecordedIterator() override = default;
 
     // Copy.
-    HdrRecordedIterator(const HdrRecordedIterator&) = delete;
-    HdrRecordedIterator& operator=(const HdrRecordedIterator&) = delete;
+    RecordedIterator(const RecordedIterator&) = delete;
+    RecordedIterator& operator=(const RecordedIterator&) = delete;
 
     // Move.
-    HdrRecordedIterator(HdrRecordedIterator&&) noexcept = default;
-    HdrRecordedIterator& operator=(HdrRecordedIterator&&) = delete;
+    RecordedIterator(RecordedIterator&&) noexcept = default;
+    RecordedIterator& operator=(RecordedIterator&&) = delete;
 
   protected:
     bool do_next() noexcept override;
 };
 
-/// HdrLinearIterator is a linear value iterator.
-class TOOLBOX_API HdrLinearIterator final : public HdrCountAddedIterator {
+/// LinearIterator is a linear value iterator.
+class TOOLBOX_API LinearIterator final : public CountAddedIterator {
   public:
-    HdrLinearIterator(const HdrHistogram& h, std::int64_t value_units_per_bucket) noexcept;
-    ~HdrLinearIterator() override = default;
+    LinearIterator(const Histogram& h, std::int64_t value_units_per_bucket) noexcept;
+    ~LinearIterator() override = default;
 
     // Copy.
-    HdrLinearIterator(const HdrLinearIterator&) = delete;
-    HdrLinearIterator& operator=(const HdrLinearIterator&) = delete;
+    LinearIterator(const LinearIterator&) = delete;
+    LinearIterator& operator=(const LinearIterator&) = delete;
 
     // Move.
-    HdrLinearIterator(HdrLinearIterator&&) noexcept = default;
-    HdrLinearIterator& operator=(HdrLinearIterator&&) = delete;
+    LinearIterator(LinearIterator&&) noexcept = default;
+    LinearIterator& operator=(LinearIterator&&) = delete;
 
   protected:
     bool do_next() noexcept override;
@@ -173,20 +173,20 @@ class TOOLBOX_API HdrLinearIterator final : public HdrCountAddedIterator {
     std::int64_t next_value_reporting_level_lowest_equivalent_;
 };
 
-/// HdrLogIterator is a logarithmic value iterator.
-class TOOLBOX_API HdrLogIterator final : public HdrCountAddedIterator {
+/// LogIterator is a logarithmic value iterator.
+class TOOLBOX_API LogIterator final : public CountAddedIterator {
   public:
-    HdrLogIterator(const HdrHistogram& h, std::int64_t value_units_first_bucket,
-                   double log_base) noexcept;
-    ~HdrLogIterator() override = default;
+    LogIterator(const Histogram& h, std::int64_t value_units_first_bucket,
+                double log_base) noexcept;
+    ~LogIterator() override = default;
 
     // Copy.
-    HdrLogIterator(const HdrLogIterator&) = delete;
-    HdrLogIterator& operator=(const HdrLogIterator&) = delete;
+    LogIterator(const LogIterator&) = delete;
+    LogIterator& operator=(const LogIterator&) = delete;
 
     // Move.
-    HdrLogIterator(HdrLogIterator&&) noexcept = default;
-    HdrLogIterator& operator=(HdrLogIterator&&) = delete;
+    LogIterator(LogIterator&&) noexcept = default;
+    LogIterator& operator=(LogIterator&&) = delete;
 
   protected:
     bool do_next() noexcept override;

--- a/toolbox/hdr/Iterator.ut.cpp
+++ b/toolbox/hdr/Iterator.ut.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(IteratorSuite)
 
 BOOST_AUTO_TEST_CASE(IteratorLinearIteratorCase)
 {
-    HdrHistogram h{1, 255, 2};
+    Histogram h{1, 255, 2};
     BOOST_TEST(h.record_value(193));
     BOOST_TEST(h.record_value(255));
     BOOST_TEST(h.record_value(0));
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(IteratorLinearIteratorCase)
     int step_count{0};
     int64_t total_count{0};
 
-    HdrLinearIterator iter{h, 64};
+    LinearIterator iter{h, 64};
     while (iter.next()) {
         total_count += iter.count_added_in_this_iteration_step();
         if (step_count == 0) {

--- a/toolbox/hdr/Utility.cpp
+++ b/toolbox/hdr/Utility.cpp
@@ -28,7 +28,7 @@ namespace toolbox {
 inline namespace hdr {
 using namespace std;
 namespace {
-int64_t get_count_at_percentile(const HdrHistogram& h, double percentile) noexcept
+int64_t get_count_at_percentile(const Histogram& h, double percentile) noexcept
 {
     if (percentile > 100.0) {
         percentile = 100.0;
@@ -38,22 +38,22 @@ int64_t get_count_at_percentile(const HdrHistogram& h, double percentile) noexce
 }
 } // namespace
 
-int64_t min(const HdrHistogram& h) noexcept
+int64_t min(const Histogram& h) noexcept
 {
     return h.min();
 }
 
-int64_t max(const HdrHistogram& h) noexcept
+int64_t max(const Histogram& h) noexcept
 {
     return h.max();
 }
 
-int64_t value_at_percentile(const HdrHistogram& h, double percentile) noexcept
+int64_t value_at_percentile(const Histogram& h, double percentile) noexcept
 {
     const int64_t count_at_percentile{get_count_at_percentile(h, percentile)};
 
     int64_t total{0};
-    HdrIterator iter{h};
+    Iterator iter{h};
     while (iter.next()) {
         total += iter.count();
         if (total >= count_at_percentile) {
@@ -63,12 +63,12 @@ int64_t value_at_percentile(const HdrHistogram& h, double percentile) noexcept
     return 0;
 }
 
-double mean(const HdrHistogram& h) noexcept
+double mean(const Histogram& h) noexcept
 {
     const auto total_count = h.total_count();
 
     int64_t total{0};
-    HdrIterator iter{h};
+    Iterator iter{h};
     while (iter.next()) {
         if (iter.count() != 0) {
             total += iter.count() * h.median_equivalent_value(iter.value());
@@ -77,13 +77,13 @@ double mean(const HdrHistogram& h) noexcept
     return double(total) / total_count;
 }
 
-double stddev(const HdrHistogram& h) noexcept
+double stddev(const Histogram& h) noexcept
 {
     const int64_t total_count{h.total_count()};
     const double mean_val{mean(h)};
 
     double geometric_dev_total{0.0};
-    HdrIterator iter{h};
+    Iterator iter{h};
     while (iter.next()) {
         if (iter.count() != 0) {
             const double dev{h.median_equivalent_value(iter.value()) - mean_val};
@@ -100,7 +100,7 @@ ostream& operator<<(ostream& os, PutPercentiles pp)
 
     os << "       Value     Percentile TotalCount 1/(1-Percentile)\n\n";
 
-    HdrPercentileIterator iter{pp.h, pp.ticks_per_half_distance};
+    PercentileIterator iter{pp.h, pp.ticks_per_half_distance};
     while (iter.next()) {
         const double value{iter.highest_equivalent_value() / pp.value_scale};
         const double percentile{iter.percentile() / 100.0};

--- a/toolbox/hdr/Utility.hpp
+++ b/toolbox/hdr/Utility.hpp
@@ -23,37 +23,37 @@
 namespace toolbox {
 /// A C++ port of HdrHistogram_c written Michael Barker and released to the public domain.
 inline namespace hdr {
-class HdrHistogram;
+class Histogram;
 
-TOOLBOX_API std::int64_t min(const HdrHistogram& h) noexcept;
-TOOLBOX_API std::int64_t max(const HdrHistogram& h) noexcept;
+TOOLBOX_API std::int64_t min(const Histogram& h) noexcept;
+TOOLBOX_API std::int64_t max(const Histogram& h) noexcept;
 
 /// Get the value at a specific percentile.
 ///
 /// \param h The histogram.
 /// \param percentile The percentile to get the value for.
 /// \return the percentile value.
-TOOLBOX_API std::int64_t value_at_percentile(const HdrHistogram& h, double percentile) noexcept;
+TOOLBOX_API std::int64_t value_at_percentile(const Histogram& h, double percentile) noexcept;
 
 /// Gets the mean for the values in the histogram.
 ///
 /// \param h The histogram.
 /// \return the mean.
-TOOLBOX_API double mean(const HdrHistogram& h) noexcept;
+TOOLBOX_API double mean(const Histogram& h) noexcept;
 
 /// Gets the standard deviation for the values in the histogram.
 ///
 /// \param h The histogram.
 /// \return the standard deviation.
-TOOLBOX_API double stddev(const HdrHistogram& h) noexcept;
+TOOLBOX_API double stddev(const Histogram& h) noexcept;
 
 struct PutPercentiles {
-    const HdrHistogram& h;
+    const Histogram& h;
     std::int32_t ticks_per_half_distance{5};
     double value_scale{1000.0};
 };
 
-inline auto put_percentiles(const HdrHistogram& h, std::int32_t ticks_per_half_distance,
+inline auto put_percentiles(const Histogram& h, std::int32_t ticks_per_half_distance,
                             double value_scale) noexcept
 {
     return PutPercentiles{h, ticks_per_half_distance, value_scale};

--- a/toolbox/hdr/Utility.ut.cpp
+++ b/toolbox/hdr/Utility.ut.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(UtilitySuite)
 
 BOOST_AUTO_TEST_CASE(CreateWithLargeValuesCase)
 {
-    HdrHistogram h{20000000, 100000000, 5};
+    Histogram h{20000000, 100000000, 5};
     BOOST_TEST(h.record_value(100000000));
     BOOST_TEST(h.record_value(20000000));
     BOOST_TEST(h.record_value(30000000));
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(HighSignificantFiguresCase)
 {
     const std::initializer_list<int64_t> vals{459876,  669187,  711612,  816326,  931423,
                                               1033197, 1131895, 2477317, 3964974, 12718782};
-    HdrHistogram h{459876, 12718782, 5};
+    Histogram h{459876, 12718782, 5};
     for (const auto val : vals) {
         BOOST_TEST(h.record_value(val));
     }
@@ -56,14 +56,14 @@ BOOST_AUTO_TEST_CASE(HighSignificantFiguresCase)
 
 BOOST_AUTO_TEST_CASE(NaNCase)
 {
-    HdrHistogram h{1, 100000, 3};
+    Histogram h{1, 100000, 3};
     BOOST_TEST(isnan(mean(h)));
     BOOST_TEST(isnan(stddev(h)));
 }
 
 BOOST_AUTO_TEST_CASE(StatsCase)
 {
-    HdrHistogram h{1, 100000, 4};
+    Histogram h{1, 100000, 4};
     for (int i{1}; i <= 100000; ++i) {
         BOOST_TEST(h.record_value(i));
     }

--- a/toolbox/http/App.cpp
+++ b/toolbox/http/App.cpp
@@ -19,7 +19,7 @@
 namespace toolbox {
 inline namespace http {
 
-HttpApp::~HttpApp() = default;
+App::~App() = default;
 
 } // namespace http
 } // namespace toolbox

--- a/toolbox/http/App.hpp
+++ b/toolbox/http/App.hpp
@@ -24,24 +24,24 @@
 namespace toolbox {
 inline namespace http {
 
-class HttpRequest;
-class HttpStream;
+class Request;
+class Stream;
 
-class TOOLBOX_API HttpApp {
+class TOOLBOX_API App {
   public:
     using Protocol = StreamProtocol;
     using Endpoint = StreamEndpoint;
 
-    HttpApp() noexcept = default;
-    virtual ~HttpApp();
+    App() noexcept = default;
+    virtual ~App();
 
     // Copy.
-    constexpr HttpApp(const HttpApp&) noexcept = default;
-    HttpApp& operator=(const HttpApp&) noexcept = default;
+    constexpr App(const App&) noexcept = default;
+    App& operator=(const App&) noexcept = default;
 
     // Move.
-    constexpr HttpApp(HttpApp&&) noexcept = default;
-    HttpApp& operator=(HttpApp&&) noexcept = default;
+    constexpr App(App&&) noexcept = default;
+    App& operator=(App&&) noexcept = default;
 
     void on_http_connect(CyclTime now, const Endpoint& ep) { do_on_http_connect(now, ep); }
     void on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept
@@ -49,11 +49,11 @@ class TOOLBOX_API HttpApp {
         do_on_http_disconnect(now, ep);
     }
     void on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                       HttpStream& os) noexcept
+                       Stream& os) noexcept
     {
         do_on_http_error(now, ep, e, os);
     }
-    void on_http_message(CyclTime now, const Endpoint& ep, const HttpRequest& req, HttpStream& os)
+    void on_http_message(CyclTime now, const Endpoint& ep, const Request& req, Stream& os)
     {
         do_on_http_message(now, ep, req, os);
     }
@@ -63,9 +63,9 @@ class TOOLBOX_API HttpApp {
     virtual void do_on_http_connect(CyclTime now, const Endpoint& ep) = 0;
     virtual void do_on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept = 0;
     virtual void do_on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                                  HttpStream& os) noexcept = 0;
-    virtual void do_on_http_message(CyclTime now, const Endpoint& ep, const HttpRequest& req,
-                                    HttpStream& os)
+                                  Stream& os) noexcept = 0;
+    virtual void do_on_http_message(CyclTime now, const Endpoint& ep, const Request& req,
+                                    Stream& os)
         = 0;
     virtual void do_on_http_timeout(CyclTime now, const Endpoint& ep) noexcept = 0;
 };

--- a/toolbox/http/Error.cpp
+++ b/toolbox/http/Error.cpp
@@ -20,44 +20,41 @@ namespace toolbox {
 using namespace std::literals::string_literals;
 inline namespace http {
 namespace {
-struct HttpErrorCategory final : std::error_category {
-    constexpr HttpErrorCategory() noexcept = default;
-    ~HttpErrorCategory() override = default;
+struct ErrorCategory final : std::error_category {
+    constexpr ErrorCategory() noexcept = default;
+    ~ErrorCategory() override = default;
 
     // Copy.
-    HttpErrorCategory(const HttpErrorCategory&) = delete;
-    HttpErrorCategory& operator=(const HttpErrorCategory&) = delete;
+    ErrorCategory(const ErrorCategory&) = delete;
+    ErrorCategory& operator=(const ErrorCategory&) = delete;
 
     // Move.
-    HttpErrorCategory(HttpErrorCategory&&) = delete;
-    HttpErrorCategory& operator=(HttpErrorCategory&&) = delete;
+    ErrorCategory(ErrorCategory&&) = delete;
+    ErrorCategory& operator=(ErrorCategory&&) = delete;
 
     const char* name() const noexcept override { return "http"; }
-    std::string message(int err) const override
-    {
-        return enum_string(static_cast<HttpStatus>(err));
-    }
+    std::string message(int err) const override { return enum_string(static_cast<Status>(err)); }
 };
 
-const HttpErrorCategory ecat_{};
+const ErrorCategory ecat_{};
 } // namespace
 
-const std::error_category& http_error_category() noexcept
+const std::error_category& error_category() noexcept
 {
     return ecat_;
 }
 
-std::error_code make_error_code(HttpStatus status)
+std::error_code make_error_code(Status status)
 {
     return {static_cast<int>(status), ecat_};
 }
 
-HttpStatus http_status(const std::error_code& ec)
+Status http_status(const std::error_code& ec)
 {
-    if (ec.category() != http_error_category()) {
-        return HttpStatus::InternalServerError;
+    if (ec.category() != error_category()) {
+        return Status::InternalServerError;
     }
-    return static_cast<HttpStatus>(ec.value());
+    return static_cast<Status>(ec.value());
 }
 
 } // namespace http

--- a/toolbox/http/Error.hpp
+++ b/toolbox/http/Error.hpp
@@ -24,16 +24,16 @@
 namespace toolbox {
 inline namespace http {
 
-TOOLBOX_API HttpStatus http_status(const std::error_code& ec);
-TOOLBOX_API const std::error_category& http_error_category() noexcept;
-TOOLBOX_API std::error_code make_error_code(HttpStatus err);
+TOOLBOX_API Status http_status(const std::error_code& ec);
+TOOLBOX_API const std::error_category& error_category() noexcept;
+TOOLBOX_API std::error_code make_error_code(Status err);
 
 } // namespace http
 } // namespace toolbox
 
 namespace std {
 template <>
-struct is_error_code_enum<toolbox::http::HttpStatus> : true_type {
+struct is_error_code_enum<toolbox::http::Status> : true_type {
 };
 } // namespace std
 

--- a/toolbox/http/Exception.cpp
+++ b/toolbox/http/Exception.cpp
@@ -19,7 +19,7 @@
 namespace toolbox {
 inline namespace http {
 
-HttpException::~HttpException() = default;
+Exception::~Exception() = default;
 
 } // namespace http
 } // namespace toolbox

--- a/toolbox/http/Exception.hpp
+++ b/toolbox/http/Exception.hpp
@@ -23,19 +23,19 @@
 namespace toolbox {
 inline namespace http {
 
-struct TOOLBOX_API HttpException : Exception {
-    explicit HttpException(HttpStatus status)
-    : Exception{status}
+struct TOOLBOX_API Exception : util::Exception {
+    explicit Exception(Status status)
+    : util::Exception{status}
     {
     }
-    HttpException(HttpStatus status, std::string_view what)
-    : Exception{status, what}
+    Exception(Status status, std::string_view what)
+    : util::Exception{status, what}
     {
     }
-    ~HttpException() override;
+    ~Exception() override;
 
   protected:
-    using Exception::Exception;
+    using util::Exception::Exception;
 };
 
 } // namespace http

--- a/toolbox/http/Parser.hpp
+++ b/toolbox/http/Parser.hpp
@@ -28,9 +28,9 @@ namespace toolbox {
 inline namespace http {
 
 template <typename DerivedT>
-class BasicHttpParser {
+class BasicParser {
   public:
-    explicit BasicHttpParser(HttpType type) noexcept
+    explicit BasicParser(Type type) noexcept
     : type_{type}
     {
         // The http_parser_init() function preserves "data".
@@ -41,24 +41,24 @@ class BasicHttpParser {
     }
 
     // Copy.
-    BasicHttpParser(const BasicHttpParser&) noexcept = default;
-    BasicHttpParser& operator=(const BasicHttpParser&) noexcept = default;
+    BasicParser(const BasicParser&) noexcept = default;
+    BasicParser& operator=(const BasicParser&) noexcept = default;
 
     // Move.
-    BasicHttpParser(BasicHttpParser&&) noexcept = default;
-    BasicHttpParser& operator=(BasicHttpParser&&) noexcept = default;
+    BasicParser(BasicParser&&) noexcept = default;
+    BasicParser& operator=(BasicParser&&) noexcept = default;
 
     int http_major() const noexcept { return parser_.http_major; }
     int http_minor() const noexcept { return parser_.http_minor; }
     int status_code() const noexcept { return parser_.status_code; }
-    HttpMethod method() const noexcept { return static_cast<HttpMethod>(parser_.method); }
+    Method method() const noexcept { return static_cast<Method>(parser_.method); }
     bool should_keep_alive() const noexcept { return http_should_keep_alive(&parser_) != 0; }
     bool body_is_final() const noexcept { return http_body_is_final(&parser_) != 0; }
 
     void pause() noexcept { http_parser_pause(&parser_, 1); }
 
   protected:
-    ~BasicHttpParser() = default;
+    ~BasicParser() = default;
 
     void reset() noexcept
     {
@@ -77,9 +77,9 @@ class BasicHttpParser {
                 // Clear pause state.
                 http_parser_pause(&parser_, 0);
             } else {
-                throw HttpException{HttpStatus::BadRequest,
-                                    err_msg() << http_errno_name(err) << ": "
-                                              << http_errno_description(err)};
+                throw Exception{Status::BadRequest,
+                                err_msg()
+                                    << http_errno_name(err) << ": " << http_errno_description(err)};
             }
         }
         return rc;
@@ -168,7 +168,7 @@ class BasicHttpParser {
     {
         return static_cast<DerivedT*>(parser->data)->on_chunk_end(CyclTime::current()) ? 0 : -1;
     }
-    HttpType type_;
+    Type type_;
     http_parser parser_;
     enum { None = 0, Field, Value } last_header_elem_;
 };

--- a/toolbox/http/Request.cpp
+++ b/toolbox/http/Request.cpp
@@ -19,7 +19,7 @@
 namespace toolbox {
 inline namespace http {
 
-HttpRequest::~HttpRequest() = default;
+Request::~Request() = default;
 
 } // namespace http
 } // namespace toolbox

--- a/toolbox/http/Request.hpp
+++ b/toolbox/http/Request.hpp
@@ -25,35 +25,35 @@
 namespace toolbox {
 inline namespace http {
 
-using HttpHeaders = std::vector<std::pair<std::string, std::string>>;
+using Headers = std::vector<std::pair<std::string, std::string>>;
 
-class TOOLBOX_API HttpRequest : public BasicUrl<HttpRequest> {
+class TOOLBOX_API Request : public BasicUrl<Request> {
   public:
-    HttpRequest() = default;
-    ~HttpRequest();
+    Request() = default;
+    ~Request();
 
     // Copy.
-    HttpRequest(const HttpRequest&) = delete;
-    HttpRequest& operator=(const HttpRequest&) = delete;
+    Request(const Request&) = delete;
+    Request& operator=(const Request&) = delete;
 
     // Move.
-    HttpRequest(HttpRequest&&) = delete;
-    HttpRequest& operator=(HttpRequest&&) = delete;
+    Request(Request&&) = delete;
+    Request& operator=(Request&&) = delete;
 
-    HttpMethod method() const noexcept { return method_; }
+    Method method() const noexcept { return method_; }
     const std::string& url() const noexcept { return url_; }
-    const HttpHeaders& headers() const noexcept { return headers_; }
+    const Headers& headers() const noexcept { return headers_; }
     const std::string& body() const noexcept { return body_; }
 
     void clear() noexcept
     {
-        method_ = HttpMethod::Get;
+        method_ = Method::Get;
         url_.clear();
         headers_.clear();
         body_.clear();
     }
     void flush() { parse(); }
-    void set_method(HttpMethod method) noexcept { method_ = method; }
+    void set_method(Method method) noexcept { method_ = method; }
     void append_url(std::string_view sv) { url_.append(sv.data(), sv.size()); }
     void append_header_field(std::string_view sv, First first)
     {
@@ -70,11 +70,12 @@ class TOOLBOX_API HttpRequest : public BasicUrl<HttpRequest> {
     void append_body(std::string_view sv) { body_.append(sv.data(), sv.size()); }
 
   private:
-    HttpMethod method_{HttpMethod::Get};
+    Method method_{Method::Get};
     std::string url_;
-    HttpHeaders headers_;
+    Headers headers_;
     std::string body_;
 };
+
 } // namespace http
 } // namespace toolbox
 

--- a/toolbox/http/Serv.hpp
+++ b/toolbox/http/Serv.hpp
@@ -25,9 +25,9 @@ namespace toolbox {
 inline namespace http {
 
 template <typename ConnT, typename AppT>
-class BasicHttpServ : public StreamAcceptor<BasicHttpServ<ConnT, AppT>> {
+class BasicServ : public StreamAcceptor<BasicServ<ConnT, AppT>> {
 
-    friend StreamAcceptor<BasicHttpServ<ConnT, AppT>>;
+    friend StreamAcceptor<BasicServ<ConnT, AppT>>;
 
     using Conn = ConnT;
     using App = AppT;
@@ -36,28 +36,28 @@ class BasicHttpServ : public StreamAcceptor<BasicHttpServ<ConnT, AppT>> {
         = boost::intrusive::member_hook<Conn, decltype(Conn::list_hook), &Conn::list_hook>;
     using ConnList = boost::intrusive::list<Conn, ConstantTimeSizeOption, MemberHookOption>;
 
-    using typename StreamAcceptor<BasicHttpServ<ConnT, AppT>>::Endpoint;
+    using typename StreamAcceptor<BasicServ<ConnT, AppT>>::Endpoint;
 
   public:
-    BasicHttpServ(CyclTime now, Reactor& r, const Endpoint& ep, App& app)
-    : StreamAcceptor<BasicHttpServ<ConnT, AppT>>{r, ep}
+    BasicServ(CyclTime now, Reactor& r, const Endpoint& ep, App& app)
+    : StreamAcceptor<BasicServ<ConnT, AppT>>{r, ep}
     , reactor_{r}
     , app_{app}
     {
     }
-    ~BasicHttpServ()
+    ~BasicServ()
     {
         const auto now = CyclTime::current();
         conn_list_.clear_and_dispose([now](auto* conn) { conn->dispose(now); });
     }
 
     // Copy.
-    BasicHttpServ(const BasicHttpServ&) = delete;
-    BasicHttpServ& operator=(const BasicHttpServ&) = delete;
+    BasicServ(const BasicServ&) = delete;
+    BasicServ& operator=(const BasicServ&) = delete;
 
     // Move.
-    BasicHttpServ(BasicHttpServ&&) = delete;
-    BasicHttpServ& operator=(BasicHttpServ&&) = delete;
+    BasicServ(BasicServ&&) = delete;
+    BasicServ& operator=(BasicServ&&) = delete;
 
   private:
     void on_sock_prepare(CyclTime now, IoSock& sock) {}
@@ -73,7 +73,7 @@ class BasicHttpServ : public StreamAcceptor<BasicHttpServ<ConnT, AppT>> {
     ConnList conn_list_;
 };
 
-using HttpServ = BasicHttpServ<HttpConn, HttpApp>;
+using Serv = BasicServ<Conn, App>;
 
 } // namespace http
 } // namespace toolbox

--- a/toolbox/http/Stream.cpp
+++ b/toolbox/http/Stream.cpp
@@ -20,7 +20,7 @@ namespace toolbox {
 inline namespace http {
 using namespace std;
 
-void HttpBuf::set_content_length(std::streamsize pos, std::streamsize len) noexcept
+void StreamBuf::set_content_length(std::streamsize pos, std::streamsize len) noexcept
 {
     auto it = pbase_ + pos;
     do {
@@ -30,9 +30,9 @@ void HttpBuf::set_content_length(std::streamsize pos, std::streamsize len) noexc
     } while (len > 0);
 }
 
-HttpBuf::~HttpBuf() = default;
+StreamBuf::~StreamBuf() = default;
 
-HttpBuf::int_type HttpBuf::overflow(int_type c) noexcept
+StreamBuf::int_type StreamBuf::overflow(int_type c) noexcept
 {
     if (c != traits_type::eof()) {
         auto buf = buf_.prepare(pcount_ + 1);
@@ -42,7 +42,7 @@ HttpBuf::int_type HttpBuf::overflow(int_type c) noexcept
     return c;
 }
 
-streamsize HttpBuf::xsputn(const char_type* s, streamsize count) noexcept
+streamsize StreamBuf::xsputn(const char_type* s, streamsize count) noexcept
 {
     auto buf = buf_.prepare(pcount_ + count);
     pbase_ = buffer_cast<char*>(buf);
@@ -51,9 +51,9 @@ streamsize HttpBuf::xsputn(const char_type* s, streamsize count) noexcept
     return count;
 }
 
-HttpStream::~HttpStream() = default;
+Stream::~Stream() = default;
 
-void HttpStream::commit() noexcept
+void Stream::commit() noexcept
 {
     if (cloff_ > 0) {
         buf_.set_content_length(cloff_, pcount() - hcount_);
@@ -61,7 +61,7 @@ void HttpStream::commit() noexcept
     buf_.commit();
 }
 
-void HttpStream::reset(HttpStatus status, const char* content_type, NoCache no_cache)
+void Stream::reset(Status status, const char* content_type, NoCache no_cache)
 {
     buf_.reset();
     toolbox::reset(*this);

--- a/toolbox/http/Stream.hpp
+++ b/toolbox/http/Stream.hpp
@@ -28,21 +28,21 @@ constexpr char ApplicationJson[]{"application/json"};
 constexpr char TextHtml[]{"text/html"};
 constexpr char TextPlain[]{"text/plain"};
 
-class TOOLBOX_API HttpBuf final : public std::streambuf {
+class TOOLBOX_API StreamBuf final : public std::streambuf {
   public:
-    explicit HttpBuf(Buffer& buf) noexcept
+    explicit StreamBuf(Buffer& buf) noexcept
     : buf_{buf}
     {
     }
-    ~HttpBuf() override;
+    ~StreamBuf() override;
 
     // Copy.
-    HttpBuf(const HttpBuf&) = delete;
-    HttpBuf& operator=(const HttpBuf&) = delete;
+    StreamBuf(const StreamBuf&) = delete;
+    StreamBuf& operator=(const StreamBuf&) = delete;
 
     // Move.
-    HttpBuf(HttpBuf&&) = delete;
-    HttpBuf& operator=(HttpBuf&&) = delete;
+    StreamBuf(StreamBuf&&) = delete;
+    StreamBuf& operator=(StreamBuf&&) = delete;
 
     std::streamsize pcount() const noexcept { return pcount_; }
     void commit() noexcept { buf_.commit(pcount_); }
@@ -63,23 +63,23 @@ class TOOLBOX_API HttpBuf final : public std::streambuf {
     std::streamsize pcount_{0};
 };
 
-class TOOLBOX_API HttpStream final : public std::ostream {
+class TOOLBOX_API Stream final : public std::ostream {
   public:
-    explicit HttpStream(Buffer& buf) noexcept
+    explicit Stream(Buffer& buf) noexcept
     : std::ostream{nullptr}
     , buf_{buf}
     {
         rdbuf(&buf_);
     }
-    ~HttpStream() override;
+    ~Stream() override;
 
     // Copy.
-    HttpStream(const HttpStream&) = delete;
-    HttpStream& operator=(const HttpStream&) = delete;
+    Stream(const Stream&) = delete;
+    Stream& operator=(const Stream&) = delete;
 
     // Move.
-    HttpStream(HttpStream&&) = delete;
-    HttpStream& operator=(HttpStream&&) = delete;
+    Stream(Stream&&) = delete;
+    Stream& operator=(Stream&&) = delete;
 
     std::streamsize pcount() const noexcept { return buf_.pcount(); }
     void commit() noexcept;
@@ -89,10 +89,10 @@ class TOOLBOX_API HttpStream final : public std::ostream {
         toolbox::reset(*this);
         cloff_ = hcount_ = 0;
     }
-    void reset(HttpStatus status, const char* content_type, NoCache no_cache = NoCache::Yes);
+    void reset(Status status, const char* content_type, NoCache no_cache = NoCache::Yes);
 
   private:
-    HttpBuf buf_;
+    StreamBuf buf_;
     /// Content-Length offset.
     std::streamsize cloff_{0};
     /// Header size.

--- a/toolbox/http/Types.cpp
+++ b/toolbox/http/Types.cpp
@@ -19,7 +19,7 @@
 namespace toolbox {
 inline namespace http {
 
-const char* enum_string(HttpStatus status) noexcept
+const char* enum_string(Status status) noexcept
 {
     switch (static_cast<int>(status)) {
 #define XX(num, name, string)                                                                      \

--- a/toolbox/http/Types.hpp
+++ b/toolbox/http/Types.hpp
@@ -28,7 +28,7 @@ enum class First : bool { No = false, Yes = true };
 
 enum class NoCache : bool { No = false, Yes = true };
 
-enum class HttpMethod : int {
+enum class Method : int {
     Delete = HTTP_DELETE,
     Get = HTTP_GET,
     Head = HTTP_HEAD,
@@ -65,17 +65,17 @@ enum class HttpMethod : int {
     Source = HTTP_SOURCE
 };
 
-inline const char* enum_string(HttpMethod method) noexcept
+inline const char* enum_string(Method method) noexcept
 {
     return http_method_str(static_cast<http_method>(method));
 }
 
-inline std::ostream& operator<<(std::ostream& os, HttpMethod method)
+inline std::ostream& operator<<(std::ostream& os, Method method)
 {
     return os << enum_string(method);
 }
 
-enum class HttpStatus : int {
+enum class Status : int {
     Ok = HTTP_STATUS_OK,
     NoContent = HTTP_STATUS_NO_CONTENT,
     BadRequest = HTTP_STATUS_BAD_REQUEST,
@@ -87,14 +87,14 @@ enum class HttpStatus : int {
     ServiceUnavailable = HTTP_STATUS_SERVICE_UNAVAILABLE
 };
 
-TOOLBOX_API const char* enum_string(HttpStatus status) noexcept;
+TOOLBOX_API const char* enum_string(Status status) noexcept;
 
-inline std::ostream& operator<<(std::ostream& os, HttpStatus status)
+inline std::ostream& operator<<(std::ostream& os, Status status)
 {
     return os << static_cast<int>(status);
 }
 
-enum class HttpType : int { Request = HTTP_REQUEST, Response = HTTP_RESPONSE };
+enum class Type : int { Request = HTTP_REQUEST, Response = HTTP_RESPONSE };
 
 } // namespace http
 } // namespace toolbox

--- a/toolbox/http/Types.ut.cpp
+++ b/toolbox/http/Types.ut.cpp
@@ -25,13 +25,13 @@ BOOST_AUTO_TEST_SUITE(TypesSuite)
 
 BOOST_AUTO_TEST_CASE(TypesCase)
 {
-    BOOST_TEST(enum_string(HttpStatus::BadRequest) == "Bad Request");
-    BOOST_TEST(enum_string(HttpStatus::Unauthorized) == "Unauthorized");
-    BOOST_TEST(enum_string(HttpStatus::Forbidden) == "Forbidden");
-    BOOST_TEST(enum_string(HttpStatus::NotFound) == "Not Found");
-    BOOST_TEST(enum_string(HttpStatus::MethodNotAllowed) == "Method Not Allowed");
-    BOOST_TEST(enum_string(HttpStatus::InternalServerError) == "Internal Server Error");
-    BOOST_TEST(enum_string(HttpStatus::ServiceUnavailable) == "Service Unavailable");
+    BOOST_TEST(enum_string(Status::BadRequest) == "Bad Request");
+    BOOST_TEST(enum_string(Status::Unauthorized) == "Unauthorized");
+    BOOST_TEST(enum_string(Status::Forbidden) == "Forbidden");
+    BOOST_TEST(enum_string(Status::NotFound) == "Not Found");
+    BOOST_TEST(enum_string(Status::MethodNotAllowed) == "Method Not Allowed");
+    BOOST_TEST(enum_string(Status::InternalServerError) == "Internal Server Error");
+    BOOST_TEST(enum_string(Status::ServiceUnavailable) == "Service Unavailable");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/http/Url.hpp
+++ b/toolbox/http/Url.hpp
@@ -82,7 +82,7 @@ class BasicUrl {
         const auto rc
             = http_parser_parse_url(url().data(), url().size(), is_connect ? 1 : 0, &parser_);
         if (rc != 0) {
-            throw HttpException{HttpStatus::BadRequest, err_msg() << "invalid url: " << url()};
+            throw Exception{Status::BadRequest, err_msg() << "invalid url: " << url()};
         }
     }
 
@@ -104,8 +104,8 @@ class Url : public BasicUrl<Url> {
     Url& operator=(const Url&) = default;
 
     // Move.
-    Url(Url&&) = default;
-    Url& operator=(Url&&) = default;
+    Url(Url&&) noexcept = default;
+    Url& operator=(Url&&) noexcept = default;
 
     const auto& url() const noexcept { return url_; }
 

--- a/toolbox/io/Epoll.hpp
+++ b/toolbox/io/Epoll.hpp
@@ -33,7 +33,7 @@ inline FileHandle epoll_create(int size, std::error_code& ec) noexcept
 {
     const auto ret = ::epoll_create(size);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -44,7 +44,7 @@ inline FileHandle epoll_create(int size)
 {
     const auto fd = ::epoll_create(size);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "epoll_create"};
+        throw std::system_error{make_error(errno), "epoll_create"};
     }
     return fd;
 }
@@ -54,7 +54,7 @@ inline FileHandle epoll_create1(int flags, std::error_code& ec) noexcept
 {
     const auto ret = ::epoll_create1(flags);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -64,7 +64,7 @@ inline FileHandle epoll_create1(int flags)
 {
     const auto fd = ::epoll_create1(flags);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "epoll_create1"};
+        throw std::system_error{make_error(errno), "epoll_create1"};
     }
     return fd;
 }
@@ -74,7 +74,7 @@ inline int epoll_ctl(int epfd, int op, int fd, epoll_event event, std::error_cod
 {
     const auto ret = ::epoll_ctl(epfd, op, fd, &event);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -84,7 +84,7 @@ inline void epoll_ctl(int epfd, int op, int fd, epoll_event event)
 {
     const auto ret = ::epoll_ctl(epfd, op, fd, &event);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "epoll_ctl"};
+        throw std::system_error{make_error(errno), "epoll_ctl"};
     }
 }
 
@@ -94,7 +94,7 @@ inline int epoll_wait(int epfd, epoll_event* events, int maxevents, int timeout,
 {
     const auto ret = ::epoll_wait(epfd, events, maxevents, timeout);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -104,7 +104,7 @@ inline int epoll_wait(int epfd, epoll_event* events, int maxevents, int timeout)
 {
     const auto ret = ::epoll_wait(epfd, events, maxevents, timeout);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "epoll_wait"};
+        throw std::system_error{make_error(errno), "epoll_wait"};
     }
     return ret;
 }
@@ -181,8 +181,8 @@ class Epoll {
     Epoll& operator=(const Epoll&) = delete;
 
     // Move.
-    Epoll(Epoll&&) = default;
-    Epoll& operator=(Epoll&&) = default;
+    Epoll(Epoll&&) noexcept = default;
+    Epoll& operator=(Epoll&&) noexcept = default;
 
     /// Returns the timer file descriptor.
     /// Exposing the timer file descriptor allows callers to check if one of the signalled events

--- a/toolbox/io/EventFd.hpp
+++ b/toolbox/io/EventFd.hpp
@@ -29,7 +29,7 @@ inline FileHandle eventfd(unsigned intval, int flags, std::error_code& ec) noexc
 {
     const auto fd = ::eventfd(intval, flags);
     if (fd < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return fd;
 }
@@ -39,7 +39,7 @@ inline FileHandle eventfd(unsigned intval, int flags)
 {
     const auto fd = ::eventfd(intval, flags);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "eventfd"};
+        throw std::system_error{make_error(errno), "eventfd"};
     }
     return fd;
 }
@@ -60,8 +60,8 @@ class EventFd {
     EventFd& operator=(const EventFd&) = delete;
 
     // Move.
-    EventFd(EventFd&&) = default;
-    EventFd& operator=(EventFd&&) = default;
+    EventFd(EventFd&&) noexcept = default;
+    EventFd& operator=(EventFd&&) noexcept = default;
 
     int fd() const noexcept { return fh_.get(); }
     std::int64_t read()

--- a/toolbox/io/File.hpp
+++ b/toolbox/io/File.hpp
@@ -34,7 +34,7 @@ inline FileHandle open(const char* path, int flags, mode_t mode, std::error_code
 {
     const auto fd = ::open(path, flags, mode);
     if (fd < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return fd;
 }
@@ -44,7 +44,7 @@ inline FileHandle open(const char* path, int flags, mode_t mode)
 {
     const auto fd = ::open(path, flags, mode);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "open"};
+        throw std::system_error{make_error(errno), "open"};
     }
     return fd;
 }
@@ -54,7 +54,7 @@ inline FileHandle open(const char* path, int flags, std::error_code& ec) noexcep
 {
     const auto fd = ::open(path, flags);
     if (fd < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return fd;
 }
@@ -64,7 +64,7 @@ inline FileHandle open(const char* path, int flags)
 {
     const auto fd = ::open(path, flags);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "open"};
+        throw std::system_error{make_error(errno), "open"};
     }
     return fd;
 }
@@ -74,7 +74,7 @@ inline std::pair<FileHandle, FileHandle> pipe2(int flags, std::error_code& ec) n
 {
     int pipefd[2];
     if (::pipe2(pipefd, flags) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return {FileHandle{pipefd[0]}, FileHandle{pipefd[1]}};
 }
@@ -84,7 +84,7 @@ inline std::pair<FileHandle, FileHandle> pipe2(int flags)
 {
     int pipefd[2];
     if (::pipe2(pipefd, flags) < 0) {
-        throw std::system_error{make_sys_error(errno), "pipe2"};
+        throw std::system_error{make_error(errno), "pipe2"};
     }
     return {FileHandle{pipefd[0]}, FileHandle{pipefd[1]}};
 }
@@ -94,7 +94,7 @@ inline void fstat(int fd, struct stat& statbuf, std::error_code& ec) noexcept
 {
     const auto ret = ::fstat(fd, &statbuf);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -103,7 +103,7 @@ inline void fstat(int fd, struct stat& statbuf)
 {
     const auto ret = ::fstat(fd, &statbuf);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "fstat"};
+        throw std::system_error{make_error(errno), "fstat"};
     }
 }
 
@@ -112,7 +112,7 @@ inline void ftruncate(int fd, off_t length, std::error_code& ec) noexcept
 {
     const auto ret = ::ftruncate(fd, length);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -121,7 +121,7 @@ inline void ftruncate(int fd, off_t length)
 {
     const auto ret = ::ftruncate(fd, length);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "ftruncate"};
+        throw std::system_error{make_error(errno), "ftruncate"};
     }
 }
 
@@ -130,7 +130,7 @@ inline ssize_t read(int fd, void* buf, std::size_t len, std::error_code& ec) noe
 {
     const auto ret = ::read(fd, buf, len);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -140,7 +140,7 @@ inline std::size_t read(int fd, void* buf, std::size_t len)
 {
     const auto ret = ::read(fd, buf, len);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "read"};
+        throw std::system_error{make_error(errno), "read"};
     }
     return ret;
 }
@@ -162,7 +162,7 @@ inline ssize_t write(int fd, const void* buf, std::size_t len, std::error_code& 
 {
     const auto ret = ::write(fd, buf, len);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -172,7 +172,7 @@ inline std::size_t write(int fd, const void* buf, std::size_t len)
 {
     const auto ret = ::write(fd, buf, len);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "write"};
+        throw std::system_error{make_error(errno), "write"};
     }
     return ret;
 }
@@ -194,7 +194,7 @@ inline int fcntl(int fd, int cmd, std::error_code& ec) noexcept
 {
     const auto ret = ::fcntl(fd, cmd);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -205,7 +205,7 @@ inline int fcntl(int fd, int cmd, ArgT arg, std::error_code& ec) noexcept
 {
     const auto ret = ::fcntl(fd, cmd, arg);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -215,7 +215,7 @@ inline int fcntl(int fd, int cmd)
 {
     const auto ret = ::fcntl(fd, cmd);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "fcntl"};
+        throw std::system_error{make_error(errno), "fcntl"};
     }
     return ret;
 }
@@ -226,7 +226,7 @@ inline int fcntl(int fd, int cmd, ArgT arg)
 {
     const auto ret = ::fcntl(fd, cmd, arg);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "fcntl"};
+        throw std::system_error{make_error(errno), "fcntl"};
     }
     return ret;
 }

--- a/toolbox/io/Handle.hpp
+++ b/toolbox/io/Handle.hpp
@@ -49,12 +49,12 @@ class BasicHandle {
     BasicHandle& operator=(const BasicHandle&) = delete;
 
     // Move.
-    constexpr BasicHandle(BasicHandle&& rhs)
+    constexpr BasicHandle(BasicHandle&& rhs) noexcept
     : id_{rhs.id_}
     {
         rhs.id_ = invalid();
     }
-    BasicHandle& operator=(BasicHandle&& rhs)
+    BasicHandle& operator=(BasicHandle&& rhs) noexcept
     {
         reset();
         swap(rhs);

--- a/toolbox/io/TimerFd.hpp
+++ b/toolbox/io/TimerFd.hpp
@@ -30,7 +30,7 @@ inline FileHandle timerfd_create(int clock_id, int flags, std::error_code& ec) n
 {
     const auto fd = ::timerfd_create(clock_id, flags);
     if (fd < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return fd;
 }
@@ -40,7 +40,7 @@ inline FileHandle timerfd_create(int clock_id, int flags)
 {
     const auto fd = ::timerfd_create(clock_id, flags);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "timerfd_create"};
+        throw std::system_error{make_error(errno), "timerfd_create"};
     }
     return fd;
 }
@@ -51,7 +51,7 @@ inline void timerfd_settime(int fd, int flags, const itimerspec& new_value, itim
 {
     const auto ret = ::timerfd_settime(fd, flags, &new_value, &old_value);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -60,7 +60,7 @@ inline void timerfd_settime(int fd, int flags, const itimerspec& new_value, itim
 {
     const auto ret = ::timerfd_settime(fd, flags, &new_value, &old_value);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "timerfd_settime"};
+        throw std::system_error{make_error(errno), "timerfd_settime"};
     }
 }
 
@@ -70,7 +70,7 @@ inline void timerfd_settime(int fd, int flags, const itimerspec& new_value,
 {
     const auto ret = ::timerfd_settime(fd, flags, &new_value, nullptr);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -79,7 +79,7 @@ inline void timerfd_settime(int fd, int flags, const itimerspec& new_value)
 {
     const auto ret = ::timerfd_settime(fd, flags, &new_value, nullptr);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "timerfd_settime"};
+        throw std::system_error{make_error(errno), "timerfd_settime"};
     }
 }
 
@@ -136,8 +136,8 @@ class TimerFd {
     TimerFd& operator=(const TimerFd&) = delete;
 
     // Move.
-    TimerFd(TimerFd&&) = default;
-    TimerFd& operator=(TimerFd&&) = default;
+    TimerFd(TimerFd&&) noexcept = default;
+    TimerFd& operator=(TimerFd&&) noexcept = default;
 
     int fd() const noexcept { return fh_.get(); }
 

--- a/toolbox/ipc/Futex.hpp
+++ b/toolbox/ipc/Futex.hpp
@@ -45,7 +45,7 @@ inline int futex_wakeup(int& uaddr, int n, std::error_code& ec) noexcept
 {
     const auto ret = detail::futex(uaddr, FUTEX_WAKE, n);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -58,7 +58,7 @@ inline int futex_wakeup(int& uaddr, int n)
 {
     const auto ret = detail::futex(uaddr, FUTEX_WAKE, n);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "futex"};
+        throw std::system_error{make_error(errno), "futex"};
     }
     return ret;
 }
@@ -106,7 +106,7 @@ inline int futex_wakeup_one(int& uaddr)
 inline void futex_wait(int& uaddr, int expected, std::error_code& ec) noexcept
 {
     if (detail::futex(uaddr, FUTEX_WAIT, expected) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -121,7 +121,7 @@ inline bool futex_wait(int& uaddr, int expected)
         if (errno == EAGAIN) {
             return false;
         }
-        throw std::system_error{make_sys_error(errno), "futex"};
+        throw std::system_error{make_error(errno), "futex"};
     }
     return true;
 }

--- a/toolbox/ipc/Mmap.hpp
+++ b/toolbox/ipc/Mmap.hpp
@@ -79,7 +79,7 @@ inline Mmap mmap(void* addr, size_t len, int prot, int flags, int fd, off_t off,
 {
     const MmapPointer p{::mmap(addr, len, prot, flags, fd, off), len};
     if (!p) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return Mmap{p};
 }
@@ -88,7 +88,7 @@ inline Mmap mmap(void* addr, size_t len, int prot, int flags, int fd, off_t off)
 {
     const MmapPointer p{::mmap(addr, len, prot, flags, fd, off), len};
     if (!p) {
-        throw std::system_error{make_sys_error(errno), "mmap"};
+        throw std::system_error{make_error(errno), "mmap"};
     }
     return Mmap{p};
 }

--- a/toolbox/ipc/Shm.hpp
+++ b/toolbox/ipc/Shm.hpp
@@ -48,7 +48,7 @@ inline key_t ftok(const char* path, int proj_id, std::error_code& ec) noexcept
 {
     const auto key = ::ftok(path, proj_id);
     if (key < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return key;
 }
@@ -59,7 +59,7 @@ inline key_t ftok(const char* path, int proj_id)
     const auto key = ::ftok(path, proj_id);
     // N.B. Negative values other than -1 are valid keys.
     if (key == -1) {
-        throw std::system_error{make_sys_error(errno), "ftok"};
+        throw std::system_error{make_error(errno), "ftok"};
     }
     return key;
 }
@@ -69,7 +69,7 @@ inline int shmget(key_t key, std::size_t size, int shmflg, std::error_code& ec) 
 {
     const auto id = ::shmget(key, size, shmflg);
     if (id < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return id;
 }
@@ -79,7 +79,7 @@ inline int shmget(key_t key, std::size_t size, int shmflg)
 {
     const auto id = ::shmget(key, size, shmflg);
     if (id < 0) {
-        throw std::system_error{make_sys_error(errno), "shmget"};
+        throw std::system_error{make_error(errno), "shmget"};
     }
     return id;
 }
@@ -91,7 +91,7 @@ ShmPtr<ValueT> shmat(int shmid, const ValueT* shmaddr, int shmflg, std::error_co
 {
     void* const addr = ::shmat(shmid, shmaddr, shmflg);
     if (reinterpret_cast<long>(addr) == -1) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
         return {nullptr, [](const void*) -> int { return 0; }};
     }
     return {static_cast<ValueT*>(addr), shmdt};
@@ -104,7 +104,7 @@ ShmPtr<ValueT> shmat(int shmid, const ValueT* shmaddr, int shmflg)
 {
     void* const addr = ::shmat(shmid, shmaddr, shmflg);
     if (reinterpret_cast<long>(addr) == -1) {
-        throw std::system_error{make_sys_error(errno), "shmat"};
+        throw std::system_error{make_error(errno), "shmat"};
     }
     return {static_cast<ValueT*>(addr), shmdt};
 }

--- a/toolbox/net/Error.hpp
+++ b/toolbox/net/Error.hpp
@@ -17,13 +17,15 @@
 #ifndef TOOLBOX_NET_ERROR_HPP
 #define TOOLBOX_NET_ERROR_HPP
 
+#include <toolbox/Config.h>
+
 #include <system_error>
 
 namespace toolbox {
 inline namespace net {
 
-const std::error_category& gai_error_category() noexcept;
-std::error_code make_gai_error_code(int err) noexcept;
+TOOLBOX_API const std::error_category& gai_error_category() noexcept;
+TOOLBOX_API std::error_code make_gai_error_code(int err) noexcept;
 
 } // namespace net
 } // namespace toolbox

--- a/toolbox/net/IoSock.hpp
+++ b/toolbox/net/IoSock.hpp
@@ -31,6 +31,18 @@ struct IoSock : Sock {
 
     void shutdown(int how) { return os::shutdown(get(), how); }
 
+    ssize_t read(void* buf, std::size_t len, std::error_code& ec) noexcept
+    {
+        return os::read(get(), buf, len, ec);
+    }
+    std::size_t read(void* buf, std::size_t len) { return os::read(get(), buf, len); }
+
+    ssize_t read(MutableBuffer buf, std::error_code& ec) noexcept
+    {
+        return os::read(get(), buf, ec);
+    }
+    std::size_t read(MutableBuffer buf) { return os::read(get(), buf); }
+
     ssize_t recv(void* buf, std::size_t len, int flags, std::error_code& ec) noexcept
     {
         return os::recv(get(), buf, len, flags, ec);
@@ -45,6 +57,18 @@ struct IoSock : Sock {
         return os::recv(get(), buf, flags, ec);
     }
     std::size_t recv(MutableBuffer buf, int flags) { return os::recv(get(), buf, flags); }
+
+    ssize_t write(const void* buf, std::size_t len, std::error_code& ec) noexcept
+    {
+        return os::write(get(), buf, len, ec);
+    }
+    std::size_t write(const void* buf, std::size_t len) { return os::write(get(), buf, len); }
+
+    ssize_t write(ConstBuffer buf, std::error_code& ec) noexcept
+    {
+        return os::write(get(), buf, ec);
+    }
+    std::size_t write(ConstBuffer buf) { return os::write(get(), buf); }
 
     ssize_t send(const void* buf, std::size_t len, int flags, std::error_code& ec) noexcept
     {

--- a/toolbox/net/RateLimit.cpp
+++ b/toolbox/net/RateLimit.cpp
@@ -53,8 +53,8 @@ RateWindow::RateWindow(const RateWindow&) = default;
 RateWindow& RateWindow::operator=(const RateWindow&) = default;
 
 // Move.
-RateWindow::RateWindow(RateWindow&&) = default;
-RateWindow& RateWindow::operator=(RateWindow&&) = default;
+RateWindow::RateWindow(RateWindow&&) noexcept = default;
+RateWindow& RateWindow::operator=(RateWindow&&) noexcept = default;
 
 void RateWindow::add(MonoTime time, size_t count) noexcept
 {

--- a/toolbox/net/RateLimit.hpp
+++ b/toolbox/net/RateLimit.hpp
@@ -65,8 +65,8 @@ class TOOLBOX_API RateWindow {
     RateWindow& operator=(const RateWindow&);
 
     // Move.
-    RateWindow(RateWindow&&);
-    RateWindow& operator=(RateWindow&&);
+    RateWindow(RateWindow&&) noexcept;
+    RateWindow& operator=(RateWindow&&) noexcept;
 
     std::size_t count() const noexcept { return count_; }
     /// Add count to time bucket.

--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -106,7 +106,7 @@ inline unsigned if_nametoindex(const char* ifname, std::error_code& ec) noexcept
     unsigned ifindex{0};
     if (ifname) {
         if (!(ifindex = ::if_nametoindex(ifname))) {
-            ec = make_sys_error(errno);
+            ec = make_error(errno);
         }
     }
     return ifindex;
@@ -118,7 +118,7 @@ inline unsigned if_nametoindex(const char* ifname)
     unsigned ifindex{0};
     if (ifname) {
         if (!(ifindex = ::if_nametoindex(ifname))) {
-            throw std::system_error{make_sys_error(errno), "if_nametoindex"};
+            throw std::system_error{make_error(errno), "if_nametoindex"};
         }
     }
     return ifindex;
@@ -129,7 +129,7 @@ inline FileHandle socket(int family, int type, int protocol, std::error_code& ec
 {
     const auto sockfd = ::socket(family, type, protocol);
     if (sockfd < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return sockfd;
 }
@@ -139,7 +139,7 @@ inline FileHandle socket(int family, int type, int protocol)
 {
     const auto sockfd = ::socket(family, type, protocol);
     if (sockfd < 0) {
-        throw std::system_error{make_sys_error(errno), "socket"};
+        throw std::system_error{make_error(errno), "socket"};
     }
     return sockfd;
 }
@@ -164,7 +164,7 @@ inline std::pair<FileHandle, FileHandle> socketpair(int family, int type, int pr
 {
     int sv[2];
     if (::socketpair(family, type, protocol, sv) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return {FileHandle{sv[0]}, FileHandle{sv[1]}};
 }
@@ -174,7 +174,7 @@ inline std::pair<FileHandle, FileHandle> socketpair(int family, int type, int pr
 {
     int sv[2];
     if (::socketpair(family, type, protocol, sv) < 0) {
-        throw std::system_error{make_sys_error(errno), "socketpair"};
+        throw std::system_error{make_error(errno), "socketpair"};
     }
     return {FileHandle{sv[0]}, FileHandle{sv[1]}};
 }
@@ -202,7 +202,7 @@ inline FileHandle accept(int sockfd, sockaddr& addr, socklen_t& addrlen,
     // The returned address is truncated if the buffer provided is too small.
     const auto fd = ::accept(sockfd, &addr, &addrlen);
     if (fd < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return fd;
 }
@@ -214,7 +214,7 @@ inline FileHandle accept(int sockfd, sockaddr& addr, socklen_t& addrlen)
     // The returned address is truncated if the buffer provided is too small.
     const auto fd = ::accept(sockfd, &addr, &addrlen);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "accept"};
+        throw std::system_error{make_error(errno), "accept"};
     }
     return fd;
 }
@@ -224,7 +224,7 @@ inline FileHandle accept(int sockfd, std::error_code& ec) noexcept
 {
     const auto fd = ::accept(sockfd, nullptr, nullptr);
     if (fd < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return fd;
 }
@@ -234,7 +234,7 @@ inline FileHandle accept(int sockfd)
 {
     const auto fd = ::accept(sockfd, nullptr, nullptr);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "accept"};
+        throw std::system_error{make_error(errno), "accept"};
     }
     return fd;
 }
@@ -265,7 +265,7 @@ inline FileHandle accept(int sockfd, EndpointT& ep)
 inline void bind(int sockfd, const sockaddr& addr, socklen_t addrlen, std::error_code& ec) noexcept
 {
     if (::bind(sockfd, &addr, addrlen) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -273,7 +273,7 @@ inline void bind(int sockfd, const sockaddr& addr, socklen_t addrlen, std::error
 inline void bind(int sockfd, const sockaddr& addr, socklen_t addrlen)
 {
     if (::bind(sockfd, &addr, addrlen) < 0) {
-        throw std::system_error{make_sys_error(errno), "bind"};
+        throw std::system_error{make_error(errno), "bind"};
     }
 }
 
@@ -296,7 +296,7 @@ inline void connect(int sockfd, const sockaddr& addr, socklen_t addrlen,
                     std::error_code& ec) noexcept
 {
     if (::connect(sockfd, &addr, addrlen) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -304,7 +304,7 @@ inline void connect(int sockfd, const sockaddr& addr, socklen_t addrlen,
 inline void connect(int sockfd, const sockaddr& addr, socklen_t addrlen)
 {
     if (::connect(sockfd, &addr, addrlen) < 0) {
-        throw std::system_error{make_sys_error(errno), "connect"};
+        throw std::system_error{make_error(errno), "connect"};
     }
 }
 
@@ -326,7 +326,7 @@ inline void connect(int sockfd, const EndpointT& ep)
 inline void listen(int sockfd, int backlog, std::error_code& ec) noexcept
 {
     if (::listen(sockfd, backlog) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -334,7 +334,7 @@ inline void listen(int sockfd, int backlog, std::error_code& ec) noexcept
 inline void listen(int sockfd, int backlog)
 {
     if (::listen(sockfd, backlog) < 0) {
-        throw std::system_error{make_sys_error(errno), "listen"};
+        throw std::system_error{make_error(errno), "listen"};
     }
 }
 
@@ -342,7 +342,7 @@ inline void listen(int sockfd, int backlog)
 inline void shutdown(int sockfd, int how, std::error_code& ec) noexcept
 {
     if (::shutdown(sockfd, how) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -350,7 +350,7 @@ inline void shutdown(int sockfd, int how, std::error_code& ec) noexcept
 inline void shutdown(int sockfd, int how)
 {
     if (::shutdown(sockfd, how) < 0) {
-        throw std::system_error{make_sys_error(errno), "shutdown"};
+        throw std::system_error{make_error(errno), "shutdown"};
     }
 }
 
@@ -359,7 +359,7 @@ inline ssize_t recv(int sockfd, void* buf, std::size_t len, int flags, std::erro
 {
     const auto ret = ::recv(sockfd, buf, len, flags);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -369,7 +369,7 @@ inline std::size_t recv(int sockfd, void* buf, std::size_t len, int flags)
 {
     const auto ret = ::recv(sockfd, buf, len, flags);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "recv"};
+        throw std::system_error{make_error(errno), "recv"};
     }
     return ret;
 }
@@ -394,7 +394,7 @@ inline ssize_t recvfrom(int sockfd, void* buf, std::size_t len, int flags, socka
     // The returned address is truncated if the buffer provided is too small.
     const auto ret = ::recvfrom(sockfd, buf, len, flags, &addr, &addrlen);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -407,7 +407,7 @@ inline std::size_t recvfrom(int sockfd, void* buf, std::size_t len, int flags, s
     // The returned address is truncated if the buffer provided is too small.
     const auto ret = ::recvfrom(sockfd, buf, len, flags, &addr, &addrlen);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "recvfrom"};
+        throw std::system_error{make_error(errno), "recvfrom"};
     }
     return ret;
 }
@@ -456,7 +456,7 @@ inline ssize_t send(int sockfd, const void* buf, std::size_t len, int flags,
 {
     const auto ret = ::send(sockfd, buf, len, flags);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -466,7 +466,7 @@ inline std::size_t send(int sockfd, const void* buf, std::size_t len, int flags)
 {
     const auto ret = ::send(sockfd, buf, len, flags);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "send"};
+        throw std::system_error{make_error(errno), "send"};
     }
     return ret;
 }
@@ -489,7 +489,7 @@ inline ssize_t sendto(int sockfd, const void* buf, std::size_t len, int flags, c
 {
     const auto ret = ::sendto(sockfd, buf, len, flags, &addr, addrlen);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return ret;
 }
@@ -500,7 +500,7 @@ inline std::size_t sendto(int sockfd, const void* buf, std::size_t len, int flag
 {
     const auto ret = ::sendto(sockfd, buf, len, flags, &addr, addrlen);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "sendto"};
+        throw std::system_error{make_error(errno), "sendto"};
     }
     return ret;
 }
@@ -545,7 +545,7 @@ inline void getsockname(int sockfd, sockaddr& addr, socklen_t& addrlen,
     // The addrlen argument is updated to contain the actual size of the source address.
     // The returned address is truncated if the buffer provided is too small.
     if (::getsockname(sockfd, &addr, &addrlen) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -555,7 +555,7 @@ inline void getsockname(int sockfd, sockaddr& addr, socklen_t& addrlen)
     // The addrlen argument is updated to contain the actual size of the source address.
     // The returned address is truncated if the buffer provided is too small.
     if (::getsockname(sockfd, &addr, &addrlen) < 0) {
-        throw std::system_error{make_sys_error(errno), "getsockname"};
+        throw std::system_error{make_error(errno), "getsockname"};
     }
 }
 
@@ -584,7 +584,7 @@ inline void getsockopt(int sockfd, int level, int optname, void* optval, socklen
                        std::error_code& ec) noexcept
 {
     if (::getsockopt(sockfd, level, optname, optval, &optlen) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -592,7 +592,7 @@ inline void getsockopt(int sockfd, int level, int optname, void* optval, socklen
 inline void getsockopt(int sockfd, int level, int optname, void* optval, socklen_t& optlen)
 {
     if (::getsockopt(sockfd, level, optname, optval, &optlen) < 0) {
-        throw std::system_error{make_sys_error(errno), "getsockopt"};
+        throw std::system_error{make_error(errno), "getsockopt"};
     }
 }
 
@@ -601,7 +601,7 @@ inline void setsockopt(int sockfd, int level, int optname, const void* optval, s
                        std::error_code& ec) noexcept
 {
     if (::setsockopt(sockfd, level, optname, optval, optlen) < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -609,7 +609,7 @@ inline void setsockopt(int sockfd, int level, int optname, const void* optval, s
 inline void setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen)
 {
     if (::setsockopt(sockfd, level, optname, optval, optlen) < 0) {
-        throw std::system_error{make_sys_error(errno), "setsockopt"};
+        throw std::system_error{make_error(errno), "setsockopt"};
     }
 }
 
@@ -636,7 +636,7 @@ inline std::error_code get_so_error(int sockfd, std::error_code& ec) noexcept
     int optval{};
     socklen_t optlen{sizeof(optval)};
     os::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &optval, optlen, ec);
-    return make_sys_error(optval);
+    return make_error(optval);
 }
 
 inline std::error_code get_so_error(int sockfd)
@@ -644,7 +644,7 @@ inline std::error_code get_so_error(int sockfd)
     int optval{};
     socklen_t optlen{sizeof(optval)};
     os::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &optval, optlen);
-    return make_sys_error(optval);
+    return make_error(optval);
 }
 
 inline int get_so_rcv_buf(int sockfd, std::error_code& ec) noexcept

--- a/toolbox/sys/Daemon.cpp
+++ b/toolbox/sys/Daemon.cpp
@@ -57,7 +57,7 @@ void daemon()
     close(STDIN_FILENO);
     const auto fd = ::open("/dev/null", O_RDONLY);
     if (fd < 0) {
-        throw std::system_error{make_sys_error(errno), "open"};
+        throw std::system_error{make_error(errno), "open"};
     }
 }
 

--- a/toolbox/sys/Error.hpp
+++ b/toolbox/sys/Error.hpp
@@ -22,7 +22,7 @@
 namespace toolbox {
 inline namespace sys {
 
-inline std::error_code make_sys_error(int err) noexcept
+inline std::error_code make_error(int err) noexcept
 {
     return std::error_code{err, std::system_category()};
 }

--- a/toolbox/sys/PidFile.cpp
+++ b/toolbox/sys/PidFile.cpp
@@ -42,7 +42,7 @@ PidFile open_pid_file(const char* path, mode_t mode)
         if (errno == EEXIST) {
             throw std::runtime_error{"daemon already running, pid: "s + to_string(pid)};
         }
-        throw std::system_error{make_sys_error(errno), "pidfile_open"};
+        throw std::system_error{make_error(errno), "pidfile_open"};
     }
     return pf;
 }
@@ -57,7 +57,7 @@ void close_pid_file(PidFile& pf) noexcept
 void write_pid_file(PidFile& pf)
 {
     if (pf && pidfile_write(pf.get()) < 0) {
-        throw std::system_error{make_sys_error(errno), "pidfile_write"};
+        throw std::system_error{make_error(errno), "pidfile_write"};
     }
 }
 

--- a/toolbox/sys/Signal.cpp
+++ b/toolbox/sys/Signal.cpp
@@ -32,7 +32,7 @@ SigWait::SigWait(std::initializer_list<int> mask)
 
     const auto err = pthread_sigmask(SIG_BLOCK, &new_mask_, &old_mask_);
     if (err != 0) {
-        throw std::system_error{make_sys_error(err), "pthread_sigmask"};
+        throw std::system_error{make_error(err), "pthread_sigmask"};
     }
 }
 
@@ -52,7 +52,7 @@ int SigWait::operator()() const
                 // Restart if interrupted by unblocked signal.
                 continue;
             }
-            throw std::system_error{make_sys_error(errno), "sigwaitinfo"};
+            throw std::system_error{make_error(errno), "sigwaitinfo"};
         }
         return info.si_signo;
     }
@@ -73,7 +73,7 @@ int SigWait::operator()(Duration timeout) const
                 // Timeout.
                 return 0;
             }
-            throw std::system_error{make_sys_error(errno), "sigtimedwait"};
+            throw std::system_error{make_error(errno), "sigtimedwait"};
         }
         return info.si_signo;
     }
@@ -85,7 +85,7 @@ void sig_block_all()
     sigfillset(&ss);
     const auto err = pthread_sigmask(SIG_SETMASK, &ss, nullptr);
     if (err != 0) {
-        throw std::system_error{make_sys_error(err), "pthread_sigmask"};
+        throw std::system_error{make_error(err), "pthread_sigmask"};
     }
 }
 

--- a/toolbox/sys/System.hpp
+++ b/toolbox/sys/System.hpp
@@ -29,7 +29,7 @@ inline void chdir(const char* path, std::error_code& ec) noexcept
 {
     const auto ret = ::chdir(path);
     if (ret < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
 }
 
@@ -38,7 +38,7 @@ inline void chdir(const char* path)
 {
     const auto ret = ::chdir(path);
     if (ret < 0) {
-        throw std::system_error{make_sys_error(errno), "chdir"};
+        throw std::system_error{make_error(errno), "chdir"};
     }
 }
 
@@ -47,7 +47,7 @@ inline pid_t fork(std::error_code& ec) noexcept
 {
     const auto pid = ::fork();
     if (pid < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return pid;
 }
@@ -57,7 +57,7 @@ inline pid_t fork()
 {
     const auto pid = ::fork();
     if (pid < 0) {
-        throw std::system_error{make_sys_error(errno), "fork"};
+        throw std::system_error{make_error(errno), "fork"};
     }
     return pid;
 }
@@ -67,7 +67,7 @@ inline pid_t setsid(std::error_code& ec) noexcept
 {
     const auto sid = ::setsid();
     if (sid < 0) {
-        ec = make_sys_error(errno);
+        ec = make_error(errno);
     }
     return sid;
 }
@@ -77,14 +77,12 @@ inline pid_t setsid()
 {
     const auto sid = ::setsid();
     if (sid < 0) {
-        throw std::system_error{make_sys_error(errno), "setsid"};
+        throw std::system_error{make_error(errno), "setsid"};
     }
     return sid;
 }
 
 } // namespace os
-inline namespace sys {
-} // namespace sys
 } // namespace toolbox
 
 #endif // TOOLBOX_SYS_SYSTEM_HPP

--- a/toolbox/sys/Thread.cpp
+++ b/toolbox/sys/Thread.cpp
@@ -71,24 +71,24 @@ void set_thread_attrs(const ThreadConfig& config)
     const auto tid = pthread_self();
     if (!config.name.empty()) {
         if (const auto err = pthread_setname_np(tid, config.name.c_str()); err != 0) {
-            throw system_error{make_sys_error(err), "pthread_setname_np"};
+            throw system_error{make_error(err), "pthread_setname_np"};
         }
     }
     if (!config.affinity.empty()) {
         const auto bs = parse_cpu_set(config.affinity);
         if (const auto err = pthread_setaffinity_np(tid, sizeof(bs), &bs); err != 0) {
-            throw system_error{make_sys_error(err), "pthread_setaffinity_np"};
+            throw system_error{make_error(err), "pthread_setaffinity_np"};
         }
     }
     if (!config.sched_policy.empty()) {
         const auto policy = parse_sched_policy(config.sched_policy);
         const auto priority = sched_get_priority_max(policy);
         if (priority == -1) {
-            throw system_error{make_sys_error(priority), "sched_get_priority_max"};
+            throw system_error{make_error(priority), "sched_get_priority_max"};
         }
         sched_param param{.sched_priority = priority};
         if (const auto err = pthread_setschedparam(tid, policy, &param); err != 0) {
-            throw system_error{make_sys_error(err), "pthread_setschedparam"};
+            throw system_error{make_error(err), "pthread_setschedparam"};
         }
     }
 }

--- a/toolbox/util/Config.cpp
+++ b/toolbox/util/Config.cpp
@@ -30,8 +30,8 @@ Config::Config(const Config&) = default;
 Config& Config::operator=(const Config&) = default;
 
 // Move.
-Config::Config(Config&&) = default;
-Config& Config::operator=(Config&&) = default;
+Config::Config(Config&&) noexcept = default;
+Config& Config::operator=(Config&&) noexcept = default;
 
 const std::string& Config::get(const std::string& key) const
 {
@@ -69,8 +69,8 @@ istream& Config::read_section(istream& is, string* next)
 MultiConfig::MultiConfig() = default;
 MultiConfig::~MultiConfig() = default;
 
-MultiConfig::MultiConfig(MultiConfig&&) = default;
-MultiConfig& MultiConfig::operator=(MultiConfig&&) = default;
+MultiConfig::MultiConfig(MultiConfig&&) noexcept = default;
+MultiConfig& MultiConfig::operator=(MultiConfig&&) noexcept = default;
 
 void MultiConfig::clear() noexcept
 {

--- a/toolbox/util/Config.hpp
+++ b/toolbox/util/Config.hpp
@@ -76,8 +76,8 @@ class TOOLBOX_API Config {
     Config& operator=(const Config&);
 
     // Move.
-    Config(Config&&);
-    Config& operator=(Config&&);
+    Config(Config&&) noexcept;
+    Config& operator=(Config&&) noexcept;
 
     /// Throws std::runtime_error if key does not exist.
     const std::string& get(const std::string& key) const;
@@ -155,8 +155,8 @@ class TOOLBOX_API MultiConfig {
     MultiConfig& operator=(const MultiConfig&) = delete;
 
     // Move.
-    MultiConfig(MultiConfig&&);
-    MultiConfig& operator=(MultiConfig&&);
+    MultiConfig(MultiConfig&&) noexcept;
+    MultiConfig& operator=(MultiConfig&&) noexcept;
 
     void clear() noexcept;
     void read(std::istream& is);

--- a/toolbox/util/Exception.hpp
+++ b/toolbox/util/Exception.hpp
@@ -42,8 +42,8 @@ class TOOLBOX_API Exception : public std::runtime_error {
     Exception& operator=(const Exception&) = default;
 
     // Move.
-    Exception(Exception&&) = default;
-    Exception& operator=(Exception&&) = default;
+    Exception(Exception&&) noexcept = default;
+    Exception& operator=(Exception&&) noexcept = default;
 
     /// Format exception as a OpenAPI JSON response message.
     /// \param os The output stream.

--- a/toolbox/util/Finally.hpp
+++ b/toolbox/util/Finally.hpp
@@ -37,8 +37,8 @@ class Finally {
     Finally& operator=(const Finally&) = delete;
 
     // Move.
-    Finally(Finally&&) = default;
-    Finally& operator=(Finally&&) = delete;
+    Finally(Finally&&) noexcept = default;
+    Finally& operator=(Finally&&) noexcept = delete;
 
   private:
     FnT fn_;

--- a/toolbox/util/RingBuffer.hpp
+++ b/toolbox/util/RingBuffer.hpp
@@ -40,8 +40,8 @@ class RingBuffer {
     RingBuffer& operator=(const RingBuffer&) = delete;
 
     // Move.
-    RingBuffer(RingBuffer&&) = default;
-    RingBuffer& operator=(RingBuffer&&) = default;
+    RingBuffer(RingBuffer&&) noexcept = default;
+    RingBuffer& operator=(RingBuffer&&) noexcept = default;
 
     /// Returns true if the container is empty.
     bool empty() const noexcept { return rpos_ == wpos_; }

--- a/toolbox/util/TypeTraits.hpp
+++ b/toolbox/util/TypeTraits.hpp
@@ -77,9 +77,11 @@ struct TypeTraits<std::string> {
 template <typename TypeT>
 struct is_string : std::is_same<char*, std::remove_cv_t<typename std::decay_t<TypeT>>>::type {
 };
+
 template <>
 struct is_string<std::string> : std::true_type {
 };
+
 template <>
 struct is_string<std::string_view> : std::true_type {
 };

--- a/toolbox/util/VarSub.cpp
+++ b/toolbox/util/VarSub.cpp
@@ -35,8 +35,8 @@ VarSub::VarSub(const VarSub&) = default;
 VarSub& VarSub::operator=(const VarSub&) = default;
 
 // Move.
-VarSub::VarSub(VarSub&&) = default;
-VarSub& VarSub::operator=(VarSub&&) = default;
+VarSub::VarSub(VarSub&&) noexcept = default;
+VarSub& VarSub::operator=(VarSub&&) noexcept = default;
 
 bool VarSub::substitute(string& s, const size_t i, size_t j, set<string>* outer) const
 {

--- a/toolbox/util/VarSub.hpp
+++ b/toolbox/util/VarSub.hpp
@@ -42,8 +42,8 @@ class TOOLBOX_API VarSub {
     VarSub& operator=(const VarSub&);
 
     // Move.
-    VarSub(VarSub&&);
-    VarSub& operator=(VarSub&&);
+    VarSub(VarSub&&) noexcept;
+    VarSub& operator=(VarSub&&) noexcept;
 
     void operator()(std::string& s) const { substitute(s, std::string::npos, 0); }
 

--- a/toolbox/util/Version.hpp
+++ b/toolbox/util/Version.hpp
@@ -87,12 +87,10 @@ inline std::size_t hash_value(toolbox::Version ver)
 } // namespace toolbox
 
 namespace std {
-
 template <>
 struct hash<toolbox::Version> {
     inline std::size_t operator()(toolbox::Version ver) const { return hash_value(ver); }
 };
-
 } // namespace std
 
 #endif // TOOLBOX_UTIL_VERSION_HPP


### PR DESCRIPTION
Namespaces can be used to disambiguate conflicting type names, so there is no need to prefix type names with the namespace name. The HTTP server in the http namespace, for example, is called Server, not HttpServer.

DEV-2599