### PR TITLE
refactor: rename output stream types

### DIFF
--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -24,19 +24,19 @@ using namespace toolbox;
 
 namespace {
 
-void on_foo(const Request& req, Stream& os)
+void on_foo(const Request& req, OStream& os)
 {
     os << "Hello, Foo!";
 }
 
-void on_bar(const Request& req, Stream& os)
+void on_bar(const Request& req, OStream& os)
 {
     os << "Hello, Bar!";
 }
 
 class ExampleApp final : public App {
   public:
-    using Slot = BasicSlot<const Request&, Stream&>;
+    using Slot = BasicSlot<const Request&, OStream&>;
     using SlotMap = RobinMap<std::string, Slot>;
 
     ~ExampleApp() override = default;
@@ -52,12 +52,12 @@ class ExampleApp final : public App {
         TOOLBOX_INFO << "http session disconnected: " << ep;
     }
     void do_on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                          Stream& os) noexcept override
+                          OStream& os) noexcept override
     {
         TOOLBOX_ERROR << "http session error: " << ep << ": " << e.what();
     }
     void do_on_http_message(CyclTime now, const Endpoint& ep, const Request& req,
-                            Stream& os) override
+                            OStream& os) override
     {
         const auto it = slot_map_.find(string{req.path()});
         if (it != slot_map_.end()) {

--- a/toolbox/http/App.hpp
+++ b/toolbox/http/App.hpp
@@ -24,8 +24,8 @@
 namespace toolbox {
 inline namespace http {
 
+class OStream;
 class Request;
-class Stream;
 
 class TOOLBOX_API App {
   public:
@@ -49,11 +49,11 @@ class TOOLBOX_API App {
         do_on_http_disconnect(now, ep);
     }
     void on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                       Stream& os) noexcept
+                       OStream& os) noexcept
     {
         do_on_http_error(now, ep, e, os);
     }
-    void on_http_message(CyclTime now, const Endpoint& ep, const Request& req, Stream& os)
+    void on_http_message(CyclTime now, const Endpoint& ep, const Request& req, OStream& os)
     {
         do_on_http_message(now, ep, req, os);
     }
@@ -63,9 +63,9 @@ class TOOLBOX_API App {
     virtual void do_on_http_connect(CyclTime now, const Endpoint& ep) = 0;
     virtual void do_on_http_disconnect(CyclTime now, const Endpoint& ep) noexcept = 0;
     virtual void do_on_http_error(CyclTime now, const Endpoint& ep, const std::exception& e,
-                                  Stream& os) noexcept = 0;
+                                  OStream& os) noexcept = 0;
     virtual void do_on_http_message(CyclTime now, const Endpoint& ep, const Request& req,
-                                    Stream& os)
+                                    OStream& os)
         = 0;
     virtual void do_on_http_timeout(CyclTime now, const Endpoint& ep) noexcept = 0;
 };

--- a/toolbox/http/Conn.hpp
+++ b/toolbox/http/Conn.hpp
@@ -274,7 +274,7 @@ class BasicConn
     Timer tmr_;
     Buffer in_, out_;
     Request req_;
-    Stream os_{out_};
+    OStream os_{out_};
     bool in_progress_{false}, write_blocked_{false};
 };
 

--- a/toolbox/http/Stream.cpp
+++ b/toolbox/http/Stream.cpp
@@ -51,9 +51,9 @@ streamsize StreamBuf::xsputn(const char_type* s, streamsize count) noexcept
     return count;
 }
 
-Stream::~Stream() = default;
+OStream::~OStream() = default;
 
-void Stream::commit() noexcept
+void OStream::commit() noexcept
 {
     if (cloff_ > 0) {
         buf_.set_content_length(cloff_, pcount() - hcount_);
@@ -61,7 +61,7 @@ void Stream::commit() noexcept
     buf_.commit();
 }
 
-void Stream::reset(Status status, const char* content_type, NoCache no_cache)
+void OStream::reset(Status status, const char* content_type, NoCache no_cache)
 {
     buf_.reset();
     toolbox::reset(*this);

--- a/toolbox/http/Stream.hpp
+++ b/toolbox/http/Stream.hpp
@@ -63,23 +63,23 @@ class TOOLBOX_API StreamBuf final : public std::streambuf {
     std::streamsize pcount_{0};
 };
 
-class TOOLBOX_API Stream final : public std::ostream {
+class TOOLBOX_API OStream final : public std::ostream {
   public:
-    explicit Stream(Buffer& buf) noexcept
+    explicit OStream(Buffer& buf) noexcept
     : std::ostream{nullptr}
     , buf_{buf}
     {
         rdbuf(&buf_);
     }
-    ~Stream() override;
+    ~OStream() override;
 
     // Copy.
-    Stream(const Stream&) = delete;
-    Stream& operator=(const Stream&) = delete;
+    OStream(const OStream&) = delete;
+    OStream& operator=(const OStream&) = delete;
 
     // Move.
-    Stream(Stream&&) = delete;
-    Stream& operator=(Stream&&) = delete;
+    OStream(OStream&&) = delete;
+    OStream& operator=(OStream&&) = delete;
 
     std::streamsize pcount() const noexcept { return buf_.pcount(); }
     void commit() noexcept;

--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -63,10 +63,10 @@ TOOLBOX_API void std_logger(int level, std::string_view msg) noexcept;
 TOOLBOX_API void sys_logger(int level, std::string_view msg) noexcept;
 
 /// Logger callback function.
-using LogMsg = StaticStream<MaxMsgSize>;
+using LogMsg = OStaticStream<MaxMsgSize>;
 
-/// Thread-local log message. This thread-local instance of StaticStream can be used to format log
-/// messages before writing to the log. Note that the StaticStream is reset each time this function
+/// Thread-local log message. This thread-local instance of OStaticStream can be used to format log
+/// messages before writing to the log. Note that the OStaticStream is reset each time this function
 /// is called.
 TOOLBOX_API LogMsg& log_msg() noexcept;
 

--- a/toolbox/util/Exception.hpp
+++ b/toolbox/util/Exception.hpp
@@ -27,7 +27,7 @@ inline namespace util {
 /// Maximum error message length.
 constexpr std::size_t MaxErrSize{511};
 
-using ErrMsg = StaticStream<MaxErrSize>;
+using ErrMsg = OStaticStream<MaxErrSize>;
 
 class TOOLBOX_API Exception : public std::runtime_error {
   public:
@@ -71,8 +71,8 @@ class TOOLBOX_API Exception : public std::runtime_error {
     std::error_code ec_;
 };
 
-/// Thread-local error message. This thread-local instance of StaticStream can be used to format
-/// error messages before throwing. Note that the StaticStream is reset each time this function is
+/// Thread-local error message. This thread-local instance of OStaticStream can be used to format
+/// error messages before throwing. Note that the OStaticStream is reset each time this function is
 /// called.
 TOOLBOX_API ErrMsg& err_msg() noexcept;
 

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -30,18 +30,18 @@ inline namespace util {
 TOOLBOX_API void reset(std::ostream& os) noexcept;
 
 template <std::size_t MaxN>
-class StaticBuf final : public std::streambuf {
+class StaticStreamBuf final : public std::streambuf {
   public:
-    StaticBuf() noexcept { reset(); }
-    ~StaticBuf() override = default;
+    StaticStreamBuf() noexcept { reset(); }
+    ~StaticStreamBuf() override = default;
 
     // Copy.
-    StaticBuf(const StaticBuf&) = delete;
-    StaticBuf& operator=(const StaticBuf&) = delete;
+    StaticStreamBuf(const StaticStreamBuf&) = delete;
+    StaticStreamBuf& operator=(const StaticStreamBuf&) = delete;
 
     // Move.
-    StaticBuf(StaticBuf&&) = delete;
-    StaticBuf& operator=(StaticBuf&&) = delete;
+    StaticStreamBuf(StaticStreamBuf&&) = delete;
+    StaticStreamBuf& operator=(StaticStreamBuf&&) = delete;
 
     const char* data() const noexcept { return pbase(); }
     bool empty() const noexcept { return pbase() == pptr(); }
@@ -54,22 +54,22 @@ class StaticBuf final : public std::streambuf {
 };
 
 template <std::size_t MaxN>
-class StaticStream final : public std::ostream {
+class OStaticStream final : public std::ostream {
   public:
-    StaticStream()
+    OStaticStream()
     : std::ostream{nullptr}
     {
         rdbuf(&buf_);
     }
-    ~StaticStream() override = default;
+    ~OStaticStream() override = default;
 
     // Copy.
-    StaticStream(const StaticStream&) = delete;
-    StaticStream& operator=(const StaticStream&) = delete;
+    OStaticStream(const OStaticStream&) = delete;
+    OStaticStream& operator=(const OStaticStream&) = delete;
 
     // Move.
-    StaticStream(StaticStream&&) = delete;
-    StaticStream& operator=(StaticStream&&) = delete;
+    OStaticStream(OStaticStream&&) = delete;
+    OStaticStream& operator=(OStaticStream&&) = delete;
 
     const char* data() const noexcept { return buf_.data(); }
     bool empty() const noexcept { return buf_.empty(); }
@@ -83,14 +83,14 @@ class StaticStream final : public std::ostream {
     };
 
   private:
-    StaticBuf<MaxN> buf_;
+    StaticStreamBuf<MaxN> buf_;
 };
 
 template <std::size_t MaxN, typename ValueT>
-auto& operator<<(StaticStream<MaxN>& ss, ValueT&& val)
+auto& operator<<(OStaticStream<MaxN>& os, ValueT&& val)
 {
-    static_cast<std::ostream&>(ss) << std::forward<ValueT>(val);
-    return ss;
+    static_cast<std::ostream&>(os) << std::forward<ValueT>(val);
+    return os;
 }
 
 using OStreamJoiner = std::experimental::ostream_joiner<char>;

--- a/toolbox/util/Stream.ut.cpp
+++ b/toolbox/util/Stream.ut.cpp
@@ -26,35 +26,35 @@ using namespace toolbox;
 
 BOOST_AUTO_TEST_SUITE(StreamSuite)
 
-BOOST_AUTO_TEST_CASE(StaticStreamCase)
+BOOST_AUTO_TEST_CASE(OStaticStreamCase)
 {
-    StaticStream<7> ss;
-    BOOST_TEST(ss.empty());
-    ss << "foo";
-    BOOST_TEST(ss.size() == 3U);
-    BOOST_TEST(ss.str() == "foo");
-    ss << ',' << "bar";
-    BOOST_TEST(ss.size() == 7U);
-    BOOST_TEST(ss.str() == "foo,bar");
+    OStaticStream<7> os;
+    BOOST_TEST(os.empty());
+    os << "foo";
+    BOOST_TEST(os.size() == 3U);
+    BOOST_TEST(os.str() == "foo");
+    os << ',' << "bar";
+    BOOST_TEST(os.size() == 7U);
+    BOOST_TEST(os.str() == "foo,bar");
 
-    ss.reset();
-    BOOST_TEST(ss.empty());
-    ss << 12345678;
-    BOOST_TEST(ss.size() == 7U);
-    BOOST_TEST(ss.str() == "1234567");
-    BOOST_TEST(!ss);
+    os.reset();
+    BOOST_TEST(os.empty());
+    os << 12345678;
+    BOOST_TEST(os.size() == 7U);
+    BOOST_TEST(os.str() == "1234567");
+    BOOST_TEST(!os);
 
-    ss.reset();
-    BOOST_TEST(!!ss);
-    BOOST_TEST((ss << "test").str() == "test");
+    os.reset();
+    BOOST_TEST(!!os);
+    BOOST_TEST((os << "test").str() == "test");
 }
 
 BOOST_AUTO_TEST_CASE(OStreamJoinerCase)
 {
     array<string, 3> arr{{"foo", "bar", "baz"}};
-    stringstream ss;
-    copy(arr.begin(), arr.end(), OStreamJoiner{ss, ','});
-    BOOST_TEST(ss.str() == "foo,bar,baz");
+    stringstream os;
+    copy(arr.begin(), arr.end(), OStreamJoiner{os, ','});
+    BOOST_TEST(os.str() == "foo,bar,baz");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add an "O" prefix to output stream type names, so that they follow industry convention.

DEV-2657