### PR TITLE
feat: Improve unformated logging

### DIFF
--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -78,12 +78,6 @@ class Log {
         log.msg_ << std::forward<ValueT>(val);
         return log;
     }
-    template <typename ValueT>
-    friend Log& operator<<(Log&& log, ValueT&& val)
-    {
-        log.msg_ << std::forward<ValueT>(val);
-        return log;
-    }
 
   public:
     enum : int {
@@ -117,12 +111,14 @@ class Log {
     Log& operator=(Log&&) = delete;
 
     constexpr explicit operator bool() const { return true; }
-    /// The function operator is provided for writing unformatted data to the log.
+    /// Function operator provided for writing unformatted data to the log.
     Log& operator()(const char* data, std::streamsize size)
     {
         msg_.write(data, size);
         return *this;
     }
+    /// Function operator provided for rvalue to lvalue conversion.
+    Log& operator()() noexcept { return *this; }
 
   private:
     const int level_;
@@ -133,7 +129,7 @@ class Log {
 } // namespace toolbox
 
 // clang-format off
-#define TOOLBOX_LOG(LEVEL) toolbox::is_log_level(LEVEL) && toolbox::Log{LEVEL}
+#define TOOLBOX_LOG(LEVEL) toolbox::is_log_level(LEVEL) && toolbox::Log{LEVEL}()
 
 #define TOOLBOX_CRIT TOOLBOX_LOG(toolbox::Log::Crit)
 #define TOOLBOX_ERROR TOOLBOX_LOG(toolbox::Log::Error)
@@ -144,7 +140,7 @@ class Log {
 #if TOOLBOX_BUILD_DEBUG
 #define TOOLBOX_DEBUG TOOLBOX_LOG(toolbox::Log::Debug)
 #else
-#define TOOLBOX_DEBUG false && toolbox::Log{toolbox::Log::Debug}
+#define TOOLBOX_DEBUG false && toolbox::Log{toolbox::Log::Debug}()
 #endif
 // clang-format on
 

--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -21,11 +21,20 @@
 #include <boost/test/unit_test.hpp>
 
 #include <cstring>
+#include <iomanip>
+#include <string_view>
 
 using namespace std;
 using namespace toolbox;
 
 namespace {
+namespace noformat {
+// Specific Log operator<< to allow non formatted writing.
+Log& operator<<(Log& log, std::string_view str)
+{
+    return log(str.data(), str.size());
+}
+} // namespace noformat
 
 template <typename T, typename U>
 struct Foo {
@@ -102,6 +111,13 @@ BOOST_AUTO_TEST_CASE(LogMacroCase)
     TOOLBOX_DEBUG << "test7: " << Foo<int, int>{10, 20};
     BOOST_TEST(last_level == Log::Info);
     BOOST_TEST(last_msg == "test6: (10,20)");
+
+    // This will log a non formatted string view, the formatting shows up on the next "formatable"
+    // parameter.
+    using namespace noformat;
+    TOOLBOX_LOG(Log::Info) << setw(3) << setfill('*') << "test8: "sv << Foo<int, int>{10, 20};
+    BOOST_TEST(last_level == Log::Info);
+    BOOST_TEST(last_msg == "test8: **(10,20)");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Although a "raw" (char*, size_t) function already exists by simplifying the
Log class a bit we can also allow custom inserter overloads directly,
which can be used for unformatted logging if required.