### PR TITLE
Feature/unformated logging benchmark

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -19,7 +19,8 @@ set(targets
   tb-ryu-bench
   tb-time-bench
   tb-timer-bench
-  tb-util-bench)
+  tb-util-bench
+  tb-log-bench)
 
 add_custom_target(tb-bench DEPENDS ${targets})
 
@@ -37,3 +38,6 @@ target_link_libraries(tb-timer-bench ${tb_bm_LIBRARY})
 
 add_executable(tb-util-bench Util.bm.cpp)
 target_link_libraries(tb-util-bench ${tb_bm_LIBRARY})
+
+add_executable(tb-log-bench Log.bm.cpp)
+target_link_libraries(tb-log-bench ${tb_bm_LIBRARY})

--- a/bench/Log.bm.cpp
+++ b/bench/Log.bm.cpp
@@ -1,0 +1,58 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2020 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <toolbox/sys/Log.hpp>
+
+#include <toolbox/bm.hpp>
+
+#include <cstring>
+
+TOOLBOX_BENCHMARK_MAIN
+
+using namespace std;
+using namespace toolbox;
+
+namespace {
+namespace noformat {
+// Specific Log operator<< to allow non formatted writing.
+Log& operator<<(Log& log, std::string_view str)
+{
+    return log(str.data(), str.size());
+}
+} // namespace noformat
+
+auto prev_level = set_log_level(Log::Info);
+auto prev_logger = set_logger(null_logger);
+
+TOOLBOX_BENCHMARK(log_formated)
+{
+    while (ctx) {
+        for (auto _ : ctx.range(5000)) {
+            TOOLBOX_LOG(Log::Info) << "BenchmarkString"sv;
+        }
+    }
+}
+
+TOOLBOX_BENCHMARK(log_unformated)
+{
+    while (ctx) {
+        for (auto _ : ctx.range(5000)) {
+            using namespace noformat;
+            TOOLBOX_LOG(Log::Info) << "BenchmarkString"sv;
+        }
+    }
+}
+
+} // namespace

--- a/toolbox/sys/Log.cpp
+++ b/toolbox/sys/Log.cpp
@@ -165,7 +165,6 @@ void sys_logger(int level, string_view msg) noexcept
 
 LogMsg& log_msg() noexcept
 {
-    log_msg_.reset();
     return log_msg_;
 }
 

--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -66,8 +66,7 @@ TOOLBOX_API void sys_logger(int level, std::string_view msg) noexcept;
 using LogMsg = OStaticStream<MaxMsgSize>;
 
 /// Thread-local log message. This thread-local instance of OStaticStream can be used to format log
-/// messages before writing to the log. Note that the OStaticStream is reset each time this function
-/// is called.
+/// messages before writing to the log.
 TOOLBOX_API LogMsg& log_msg() noexcept;
 
 // Inspired by techniques developed by Rodrigo Fernandes.
@@ -100,7 +99,11 @@ class Log {
     , msg_{log_msg()}
     {
     }
-    ~Log() { write_log(level_, msg_); }
+    ~Log()
+    {
+        write_log(level_, msg_);
+        msg_.reset();
+    }
 
     // Copy.
     Log(const Log&) = delete;

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -76,11 +76,7 @@ class OStaticStream final : public std::ostream {
     std::size_t size() const noexcept { return buf_.size(); }
     std::string_view str() const noexcept { return buf_.str(); }
     operator std::string_view() const noexcept { return buf_.str(); }
-    void reset() noexcept
-    {
-        buf_.reset();
-        toolbox::reset(*this);
-    };
+    void reset() noexcept { buf_.reset(); };
 
   private:
     StaticStreamBuf<MaxN> buf_;

--- a/toolbox/util/Stream.ut.cpp
+++ b/toolbox/util/Stream.ut.cpp
@@ -37,6 +37,7 @@ BOOST_AUTO_TEST_CASE(OStaticStreamCase)
     BOOST_TEST(os.size() == 7U);
     BOOST_TEST(os.str() == "foo,bar");
 
+    os.clear();
     os.reset();
     BOOST_TEST(os.empty());
     os << 12345678;
@@ -44,6 +45,7 @@ BOOST_AUTO_TEST_CASE(OStaticStreamCase)
     BOOST_TEST(os.str() == "1234567");
     BOOST_TEST(!os);
 
+    os.clear();
     os.reset();
     BOOST_TEST(!!os);
     BOOST_TEST((os << "test").str() == "test");


### PR DESCRIPTION
Not calling, flag / setting reset on every log line yields significant performance benefits. This does mean that changes to io fields (width, spacing, good, etc) will persist across log calls, and that it's now the responsibility of the caller to restore whatever modifiers are set. OStringStream reuse is now somewhat similar to the stringstream reuse idiom:

```c++
stringstream ss;
(...)
ss.str("");
ss.clear();
```

with

```c++
OStaticStream<7> os;
(...)
os.reset()
os.clear()
```

Benchmark results (Before/After):

NAME|COUNT|MIN|%50|%95|%99|%99.9|%99.99
----|-----|---|---|---|---|-----|------
log_formated|95225000|0.03|0.03|0.032|0.032|0.036|0.041
log_unformated|96840000|0.028|0.03|0.031|0.032|0.042|0.043

NAME|COUNT|MIN|%50|%95|%99|%99.9|%99.99
----|-----|---|---|---|---|-----|------
log_formated|167730000|0.017|0.017|0.018|0.018|0.02|0.02
log_unformated|170380000|0.017|0.017|0.017|0.018|0.019|0.02