### PR TITLE
feat(stream): manipulator for i/o state reset

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -15,14 +15,17 @@
 # limitations under the License.
 
 set(targets
+  tb-log-bench
   tb-map-bench
   tb-ryu-bench
   tb-time-bench
   tb-timer-bench
-  tb-util-bench
-  tb-log-bench)
+  tb-util-bench)
 
 add_custom_target(tb-bench DEPENDS ${targets})
+
+add_executable(tb-log-bench Log.bm.cpp)
+target_link_libraries(tb-log-bench ${tb_bm_LIBRARY})
 
 add_executable(tb-map-bench Map.bm.cpp)
 target_link_libraries(tb-map-bench ${tb_bm_LIBRARY})
@@ -38,6 +41,3 @@ target_link_libraries(tb-timer-bench ${tb_bm_LIBRARY})
 
 add_executable(tb-util-bench Util.bm.cpp)
 target_link_libraries(tb-util-bench ${tb_bm_LIBRARY})
-
-add_executable(tb-log-bench Log.bm.cpp)
-target_link_libraries(tb-log-bench ${tb_bm_LIBRARY})

--- a/toolbox/http/Stream.cpp
+++ b/toolbox/http/Stream.cpp
@@ -64,7 +64,7 @@ void OStream::commit() noexcept
 void OStream::reset(Status status, const char* content_type, NoCache no_cache)
 {
     buf_.reset();
-    toolbox::reset(*this);
+    *this << reset_state;
 
     *this << "HTTP/1.1 " << status << ' ' << enum_string(status);
     if (no_cache == NoCache::Yes) {

--- a/toolbox/http/Stream.hpp
+++ b/toolbox/http/Stream.hpp
@@ -86,7 +86,7 @@ class TOOLBOX_API OStream final : public std::ostream {
     void reset() noexcept
     {
         buf_.reset();
-        toolbox::reset(*this);
+        *this << reset_state;
         cloff_ = hcount_ = 0;
     }
     void reset(Status status, const char* content_type, NoCache no_cache = NoCache::Yes);

--- a/toolbox/util/Stream.cpp
+++ b/toolbox/util/Stream.cpp
@@ -19,15 +19,18 @@
 namespace toolbox {
 inline namespace util {
 using namespace std;
+namespace detail {
 
-void reset(ostream& os) noexcept
+ostream& operator<<(ostream& os, ResetState) noexcept
 {
     os.clear();
     os.fill(os.widen(' '));
     os.flags(ios_base::skipws | ios_base::dec);
     os.precision(6);
     os.width(0);
+    return os;
 }
 
+} // namespace detail
 } // namespace util
 } // namespace toolbox

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -26,6 +26,16 @@
 
 namespace toolbox {
 inline namespace util {
+namespace detail {
+
+struct ResetState {
+};
+TOOLBOX_API std::ostream& operator<<(std::ostream& os, ResetState) noexcept;
+
+} // namespace detail
+
+/// I/O manipulator that resets I/O state.
+constexpr detail::ResetState reset_state{};
 
 TOOLBOX_API void reset(std::ostream& os) noexcept;
 


### PR DESCRIPTION
Replace the "reset" free function with an equivalent I/O manipulator that can be used to reset the state of the logger.