### PR TITLE
fix(github): remove set-env and add-path commands

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Set release version
         run: |
           release_tag=$(echo ${GITHUB_REF##*/})
-          echo ::set-env name=RELEASE_TAG::$release_tag
-          echo ::set-env name=RELEASE_VERSION::$(echo $release_tag | sed "s,^v,,")
+          echo "RELEASE_TAG=$release_tag" >>$GITHUB_ENV
+          echo "RELEASE_VERSION=$(echo $release_tag | sed 's,^v,,')" >>$GITHUB_ENV
 
       - name: Configure project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Set release version
         run: |
           release_tag=$(echo ${GITHUB_REF##*/})
-          echo ::set-env name=RELEASE_TAG::$release_tag
-          echo ::set-env name=RELEASE_VERSION::$(echo $release_tag | sed "s,^v,,")
+          echo "RELEASE_TAG=$release_tag" >>$GITHUB_ENV
+          echo "RELEASE_VERSION=$(echo $release_tag | sed 's,^v,,')" >>$GITHUB_ENV
 
       - name: Configure project
         run: |


### PR DESCRIPTION
A moderate security vulnerability has been identified in the GitHub Actions runner that can allow environment variable and path injection in workflows that log untrusted data to STDOUT. This can result in environment variables being introduced or modified without the intention of the workflow author.

DEV-2747