### PR TITLE
refactor(github): no need for sed subshell

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           release_tag=$(echo ${GITHUB_REF##*/})
           echo "RELEASE_TAG=$release_tag" >>$GITHUB_ENV
-          echo "RELEASE_VERSION=$(echo $release_tag | sed 's,^v,,')" >>$GITHUB_ENV
+          echo "RELEASE_VERSION=${release_tag#v}" >>$GITHUB_ENV
 
       - name: Configure project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           release_tag=$(echo ${GITHUB_REF##*/})
           echo "RELEASE_TAG=$release_tag" >>$GITHUB_ENV
-          echo "RELEASE_VERSION=$(echo $release_tag | sed 's,^v,,')" >>$GITHUB_ENV
+          echo "RELEASE_VERSION=${release_tag#v}" >>$GITHUB_ENV
 
       - name: Configure project
         run: |


### PR DESCRIPTION
The "v" prefix was trimmed from the release tag using a sed expression.
Bash parameter expansions have direct support for prefix removal, so the sed subshell is unnecessary.

DEV-2747