### PR TITLE
fix: allocator in wrong namespace

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,5 +1,5 @@
 # The Reactive C++ Toolbox.
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,5 @@
 # The Reactive C++ Toolbox.
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # The Reactive C++ Toolbox.
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bench/Log.bm.cpp
+++ b/bench/Log.bm.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bench/Map.bm.cpp
+++ b/bench/Map.bm.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bench/Ryu.bm.cpp
+++ b/bench/Ryu.bm.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bench/Time.bm.cpp
+++ b/bench/Time.bm.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bench/Timer.bm.cpp
+++ b/bench/Timer.bm.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bench/Util.bm.cpp
+++ b/bench/Util.bm.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clang-format.sh.in
+++ b/clang-format.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cppcheck.sh.in
+++ b/cppcheck.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,5 +1,5 @@
 # The Reactive C++ Toolbox.
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/cmake/CMakeLists.txt
+++ b/etc/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # The Reactive C++ Toolbox.
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/cmake/FindSystemTap.cmake
+++ b/etc/cmake/FindSystemTap.cmake
@@ -1,5 +1,5 @@
 # The Reactive C++ Toolbox.
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/dotdepend.pl
+++ b/etc/dotdepend.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/example/EchoClnt.cpp
+++ b/example/EchoClnt.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/EchoServ.cpp
+++ b/example/EchoServ.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/image/CMakeLists.txt
+++ b/image/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2020 Reactive Markets Limited
+# Copyright (C) 2021 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/toolbox/Config.h.in
+++ b/toolbox/Config.h.in
@@ -1,7 +1,7 @@
 /*
  * The Reactive C++ Toolbox.
  * Copyright (C) 2013-2019 Swirly Cloud Limited
- * Copyright (C) 2020 Reactive Markets Limited
+ * Copyright (C) 2021 Reactive Markets Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/toolbox/Main.ut.cpp
+++ b/toolbox/Main.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm.hpp
+++ b/toolbox/bm.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Benchmark.cpp
+++ b/toolbox/bm/Benchmark.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Benchmark.hpp
+++ b/toolbox/bm/Benchmark.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Ctx.cpp
+++ b/toolbox/bm/Ctx.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Ctx.hpp
+++ b/toolbox/bm/Ctx.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Range.cpp
+++ b/toolbox/bm/Range.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Range.hpp
+++ b/toolbox/bm/Range.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Record.cpp
+++ b/toolbox/bm/Record.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Record.hpp
+++ b/toolbox/bm/Record.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Suite.cpp
+++ b/toolbox/bm/Suite.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Suite.hpp
+++ b/toolbox/bm/Suite.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Utility.cpp
+++ b/toolbox/bm/Utility.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/bm/Utility.hpp
+++ b/toolbox/bm/Utility.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/contrib/libutil.h
+++ b/toolbox/contrib/libutil.h
@@ -1,7 +1,7 @@
 /*
  * The Reactive C++ Toolbox.
  * Copyright (C) 2013-2019 Swirly Cloud Limited
- * Copyright (C) 2020 Reactive Markets Limited
+ * Copyright (C) 2021 Reactive Markets Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/toolbox/hdr.hpp
+++ b/toolbox/hdr.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Histogram.cpp
+++ b/toolbox/hdr/Histogram.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Histogram.hpp
+++ b/toolbox/hdr/Histogram.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Histogram.ut.cpp
+++ b/toolbox/hdr/Histogram.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Iterator.cpp
+++ b/toolbox/hdr/Iterator.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Iterator.hpp
+++ b/toolbox/hdr/Iterator.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Iterator.ut.cpp
+++ b/toolbox/hdr/Iterator.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Utility.cpp
+++ b/toolbox/hdr/Utility.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Utility.hpp
+++ b/toolbox/hdr/Utility.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/hdr/Utility.ut.cpp
+++ b/toolbox/hdr/Utility.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http.hpp
+++ b/toolbox/http.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/App.cpp
+++ b/toolbox/http/App.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/App.hpp
+++ b/toolbox/http/App.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Conn.cpp
+++ b/toolbox/http/Conn.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Conn.hpp
+++ b/toolbox/http/Conn.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Error.cpp
+++ b/toolbox/http/Error.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Error.hpp
+++ b/toolbox/http/Error.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Exception.cpp
+++ b/toolbox/http/Exception.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Exception.hpp
+++ b/toolbox/http/Exception.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Parser.cpp
+++ b/toolbox/http/Parser.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Parser.hpp
+++ b/toolbox/http/Parser.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Parser.ut.cpp
+++ b/toolbox/http/Parser.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Request.cpp
+++ b/toolbox/http/Request.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Request.hpp
+++ b/toolbox/http/Request.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Serv.cpp
+++ b/toolbox/http/Serv.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Serv.hpp
+++ b/toolbox/http/Serv.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Stream.cpp
+++ b/toolbox/http/Stream.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Stream.hpp
+++ b/toolbox/http/Stream.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Types.cpp
+++ b/toolbox/http/Types.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Types.hpp
+++ b/toolbox/http/Types.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Types.ut.cpp
+++ b/toolbox/http/Types.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Url.cpp
+++ b/toolbox/http/Url.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Url.hpp
+++ b/toolbox/http/Url.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/http/Url.ut.cpp
+++ b/toolbox/http/Url.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io.hpp
+++ b/toolbox/io.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Buffer.cpp
+++ b/toolbox/io/Buffer.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Buffer.hpp
+++ b/toolbox/io/Buffer.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Buffer.ut.cpp
+++ b/toolbox/io/Buffer.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Disposer.cpp
+++ b/toolbox/io/Disposer.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Disposer.hpp
+++ b/toolbox/io/Disposer.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Disposer.ut.cpp
+++ b/toolbox/io/Disposer.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Epoll.cpp
+++ b/toolbox/io/Epoll.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Epoll.hpp
+++ b/toolbox/io/Epoll.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Event.cpp
+++ b/toolbox/io/Event.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Event.hpp
+++ b/toolbox/io/Event.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/EventFd.cpp
+++ b/toolbox/io/EventFd.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/EventFd.hpp
+++ b/toolbox/io/EventFd.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/File.cpp
+++ b/toolbox/io/File.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/File.hpp
+++ b/toolbox/io/File.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Handle.cpp
+++ b/toolbox/io/Handle.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Handle.hpp
+++ b/toolbox/io/Handle.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Handle.ut.cpp
+++ b/toolbox/io/Handle.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Hook.cpp
+++ b/toolbox/io/Hook.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Hook.hpp
+++ b/toolbox/io/Hook.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Hook.ut.cpp
+++ b/toolbox/io/Hook.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Reactor.cpp
+++ b/toolbox/io/Reactor.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Reactor.hpp
+++ b/toolbox/io/Reactor.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Reactor.ut.cpp
+++ b/toolbox/io/Reactor.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Runner.cpp
+++ b/toolbox/io/Runner.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Runner.hpp
+++ b/toolbox/io/Runner.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Timer.cpp
+++ b/toolbox/io/Timer.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Timer.hpp
+++ b/toolbox/io/Timer.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Timer.ut.cpp
+++ b/toolbox/io/Timer.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/TimerFd.cpp
+++ b/toolbox/io/TimerFd.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/TimerFd.hpp
+++ b/toolbox/io/TimerFd.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Waker.cpp
+++ b/toolbox/io/Waker.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/io/Waker.hpp
+++ b/toolbox/io/Waker.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc.hpp
+++ b/toolbox/ipc.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Futex.cpp
+++ b/toolbox/ipc/Futex.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Futex.hpp
+++ b/toolbox/ipc/Futex.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Mmap.cpp
+++ b/toolbox/ipc/Mmap.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Mmap.hpp
+++ b/toolbox/ipc/Mmap.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/MpmcQueue.cpp
+++ b/toolbox/ipc/MpmcQueue.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/MpmcQueue.hpp
+++ b/toolbox/ipc/MpmcQueue.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Msg.cpp
+++ b/toolbox/ipc/Msg.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Msg.hpp
+++ b/toolbox/ipc/Msg.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Shm.cpp
+++ b/toolbox/ipc/Shm.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/ipc/Shm.hpp
+++ b/toolbox/ipc/Shm.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net.hpp
+++ b/toolbox/net.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/DgramSock.cpp
+++ b/toolbox/net/DgramSock.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/DgramSock.hpp
+++ b/toolbox/net/DgramSock.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Endian.cpp
+++ b/toolbox/net/Endian.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Endian.hpp
+++ b/toolbox/net/Endian.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Endpoint.cpp
+++ b/toolbox/net/Endpoint.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Endpoint.hpp
+++ b/toolbox/net/Endpoint.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Endpoint.ut.cpp
+++ b/toolbox/net/Endpoint.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Error.cpp
+++ b/toolbox/net/Error.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Error.hpp
+++ b/toolbox/net/Error.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Frame.cpp
+++ b/toolbox/net/Frame.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Frame.hpp
+++ b/toolbox/net/Frame.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Frame.ut.cpp
+++ b/toolbox/net/Frame.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/IoSock.cpp
+++ b/toolbox/net/IoSock.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/IoSock.hpp
+++ b/toolbox/net/IoSock.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/IoSock.ut.cpp
+++ b/toolbox/net/IoSock.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/IpAddr.cpp
+++ b/toolbox/net/IpAddr.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/IpAddr.hpp
+++ b/toolbox/net/IpAddr.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/McastSock.cpp
+++ b/toolbox/net/McastSock.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/McastSock.hpp
+++ b/toolbox/net/McastSock.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Protocol.cpp
+++ b/toolbox/net/Protocol.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Protocol.hpp
+++ b/toolbox/net/Protocol.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/RateLimit.cpp
+++ b/toolbox/net/RateLimit.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/RateLimit.hpp
+++ b/toolbox/net/RateLimit.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/RateLimit.ut.cpp
+++ b/toolbox/net/RateLimit.ut.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Resolver.cpp
+++ b/toolbox/net/Resolver.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Resolver.hpp
+++ b/toolbox/net/Resolver.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Resolver.ut.cpp
+++ b/toolbox/net/Resolver.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Runner.cpp
+++ b/toolbox/net/Runner.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Runner.hpp
+++ b/toolbox/net/Runner.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Runner.ut.cpp
+++ b/toolbox/net/Runner.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Socket.cpp
+++ b/toolbox/net/Socket.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/Socket.ut.cpp
+++ b/toolbox/net/Socket.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/StreamAcceptor.cpp
+++ b/toolbox/net/StreamAcceptor.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/StreamAcceptor.hpp
+++ b/toolbox/net/StreamAcceptor.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/StreamConnector.cpp
+++ b/toolbox/net/StreamConnector.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/StreamConnector.hpp
+++ b/toolbox/net/StreamConnector.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/StreamSock.cpp
+++ b/toolbox/net/StreamSock.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/net/StreamSock.hpp
+++ b/toolbox/net/StreamSock.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys.hpp
+++ b/toolbox/sys.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Daemon.cpp
+++ b/toolbox/sys/Daemon.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Daemon.hpp
+++ b/toolbox/sys/Daemon.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Date.cpp
+++ b/toolbox/sys/Date.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Date.hpp
+++ b/toolbox/sys/Date.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Date.ut.cpp
+++ b/toolbox/sys/Date.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Error.cpp
+++ b/toolbox/sys/Error.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Error.hpp
+++ b/toolbox/sys/Error.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Limits.cpp
+++ b/toolbox/sys/Limits.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Limits.hpp
+++ b/toolbox/sys/Limits.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Log.cpp
+++ b/toolbox/sys/Log.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/PidFile.cpp
+++ b/toolbox/sys/PidFile.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/PidFile.hpp
+++ b/toolbox/sys/PidFile.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Signal.cpp
+++ b/toolbox/sys/Signal.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Signal.hpp
+++ b/toolbox/sys/Signal.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/System.cpp
+++ b/toolbox/sys/System.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/System.hpp
+++ b/toolbox/sys/System.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Thread.cpp
+++ b/toolbox/sys/Thread.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Thread.hpp
+++ b/toolbox/sys/Thread.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Thread.ut.cpp
+++ b/toolbox/sys/Thread.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Time.cpp
+++ b/toolbox/sys/Time.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Time.hpp
+++ b/toolbox/sys/Time.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Time.ut.cpp
+++ b/toolbox/sys/Time.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Trace.cpp
+++ b/toolbox/sys/Trace.cpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/sys/Trace.hpp
+++ b/toolbox/sys/Trace.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util.hpp
+++ b/toolbox/util.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Alarm.cpp
+++ b/toolbox/util/Alarm.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Alarm.hpp
+++ b/toolbox/util/Alarm.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Argv.cpp
+++ b/toolbox/util/Argv.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Argv.hpp
+++ b/toolbox/util/Argv.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Argv.ut.cpp
+++ b/toolbox/util/Argv.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Array.cpp
+++ b/toolbox/util/Array.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Array.hpp
+++ b/toolbox/util/Array.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Array.ut.cpp
+++ b/toolbox/util/Array.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Config.cpp
+++ b/toolbox/util/Config.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Config.hpp
+++ b/toolbox/util/Config.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Config.ut.cpp
+++ b/toolbox/util/Config.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Enum.cpp
+++ b/toolbox/util/Enum.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Enum.hpp
+++ b/toolbox/util/Enum.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Enum.ut.cpp
+++ b/toolbox/util/Enum.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Exception.cpp
+++ b/toolbox/util/Exception.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Exception.hpp
+++ b/toolbox/util/Exception.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Exception.ut.cpp
+++ b/toolbox/util/Exception.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Finally.cpp
+++ b/toolbox/util/Finally.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Finally.hpp
+++ b/toolbox/util/Finally.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Finally.ut.cpp
+++ b/toolbox/util/Finally.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/IntTypes.cpp
+++ b/toolbox/util/IntTypes.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/IntTypes.hpp
+++ b/toolbox/util/IntTypes.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/IntTypes.ut.cpp
+++ b/toolbox/util/IntTypes.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Math.cpp
+++ b/toolbox/util/Math.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Math.hpp
+++ b/toolbox/util/Math.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Math.ut.cpp
+++ b/toolbox/util/Math.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/MemAlloc.cpp
+++ b/toolbox/util/MemAlloc.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/MemAlloc.cpp
+++ b/toolbox/util/MemAlloc.cpp
@@ -17,7 +17,6 @@
 #include "MemAlloc.hpp"
 
 namespace toolbox {
-inline namespace util {
 using namespace std;
 
 TOOLBOX_WEAK void* alloc(size_t size);
@@ -53,5 +52,4 @@ void dealloc(void* ptr, size_t size, align_val_t al) noexcept
 #endif
 }
 
-} // namespace util
 } // namespace toolbox

--- a/toolbox/util/MemAlloc.hpp
+++ b/toolbox/util/MemAlloc.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/MemAlloc.hpp
+++ b/toolbox/util/MemAlloc.hpp
@@ -22,12 +22,13 @@
 #include <new>
 
 namespace toolbox {
-inline namespace util {
 
 TOOLBOX_API void* alloc(std::size_t size);
 TOOLBOX_API void* alloc(std::size_t size, std::align_val_t al);
 TOOLBOX_API void dealloc(void* ptr, std::size_t size) noexcept;
 TOOLBOX_API void dealloc(void* ptr, std::size_t size, std::align_val_t al) noexcept;
+
+inline namespace util {
 
 struct MemAlloc {
     static void* operator new(std::size_t size) { return alloc(size); }

--- a/toolbox/util/MemAlloc.ut.cpp
+++ b/toolbox/util/MemAlloc.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Options.cpp
+++ b/toolbox/util/Options.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Options.hpp
+++ b/toolbox/util/Options.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Options.ut.cpp
+++ b/toolbox/util/Options.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RefCount.cpp
+++ b/toolbox/util/RefCount.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RefCount.hpp
+++ b/toolbox/util/RefCount.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RefCount.ut.cpp
+++ b/toolbox/util/RefCount.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RingBuffer.cpp
+++ b/toolbox/util/RingBuffer.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RingBuffer.hpp
+++ b/toolbox/util/RingBuffer.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RingBuffer.ut.cpp
+++ b/toolbox/util/RingBuffer.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RobinHood.cpp
+++ b/toolbox/util/RobinHood.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/RobinHood.hpp
+++ b/toolbox/util/RobinHood.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Ryu.cpp
+++ b/toolbox/util/Ryu.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Ryu.hpp
+++ b/toolbox/util/Ryu.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Ryu.ut.cpp
+++ b/toolbox/util/Ryu.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Slot.cpp
+++ b/toolbox/util/Slot.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Slot.hpp
+++ b/toolbox/util/Slot.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Slot.ut.cpp
+++ b/toolbox/util/Slot.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Stream.cpp
+++ b/toolbox/util/Stream.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Stream.ut.cpp
+++ b/toolbox/util/Stream.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/String.cpp
+++ b/toolbox/util/String.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/String.hpp
+++ b/toolbox/util/String.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/String.ut.cpp
+++ b/toolbox/util/String.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/StringBuf.cpp
+++ b/toolbox/util/StringBuf.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/StringBuf.hpp
+++ b/toolbox/util/StringBuf.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/StringBuf.ut.cpp
+++ b/toolbox/util/StringBuf.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Struct.cpp
+++ b/toolbox/util/Struct.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Struct.hpp
+++ b/toolbox/util/Struct.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Struct.ut.cpp
+++ b/toolbox/util/Struct.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Tokeniser.cpp
+++ b/toolbox/util/Tokeniser.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Tokeniser.hpp
+++ b/toolbox/util/Tokeniser.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Tokeniser.ut.cpp
+++ b/toolbox/util/Tokeniser.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Traits.cpp
+++ b/toolbox/util/Traits.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Traits.hpp
+++ b/toolbox/util/Traits.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Traits.ut.cpp
+++ b/toolbox/util/Traits.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/TypeTraits.cpp
+++ b/toolbox/util/TypeTraits.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/TypeTraits.hpp
+++ b/toolbox/util/TypeTraits.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Utility.cpp
+++ b/toolbox/util/Utility.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Utility.hpp
+++ b/toolbox/util/Utility.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Utility.ut.cpp
+++ b/toolbox/util/Utility.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/VarSub.cpp
+++ b/toolbox/util/VarSub.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/VarSub.hpp
+++ b/toolbox/util/VarSub.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/VarSub.ut.cpp
+++ b/toolbox/util/VarSub.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Variant.cpp
+++ b/toolbox/util/Variant.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Variant.hpp
+++ b/toolbox/util/Variant.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Version.cpp
+++ b/toolbox/util/Version.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Version.hpp
+++ b/toolbox/util/Version.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/toolbox/util/Version.ut.cpp
+++ b/toolbox/util/Version.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2020 Reactive Markets Limited
+// Copyright (C) 2021 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Memory allocation functions were placed in the wrong namespace so they were not overriding the default weak symbols defined in toolbox.

DEV-2893