### PR TITLE
feat(log): replace Storage class with void pointer

### DIFF
--- a/toolbox/sys/Log.cpp
+++ b/toolbox/sys/Log.cpp
@@ -122,9 +122,9 @@ void std_logger(int level, LogMsgPtr msg, std::size_t size) noexcept
                     static_cast<int>(gettid()));
     char tail{'\n'};
     iovec iov[] = {
-        {head, hlen},        //
-        {msg->data(), size}, //
-        {&tail, 1}           //
+        {head, hlen},      //
+        {msg.get(), size}, //
+        {&tail, 1}         //
     };
 
     int fd{level > Log::Error ? STDOUT_FILENO : STDERR_FILENO};
@@ -159,7 +159,7 @@ void sys_logger(int level, LogMsgPtr msg, std::size_t size) noexcept
     default:
         prio = LOG_DEBUG;
     }
-    syslog(prio, "%.*s", static_cast<int>(size), msg->data());
+    syslog(prio, "%.*s", static_cast<int>(size), static_cast<const char*>(msg.get()));
 }
 
 LogStream& log_stream() noexcept

--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -23,7 +23,6 @@
 namespace toolbox {
 inline namespace sys {
 
-using LogMsg = Storage<MaxLogLine>;
 using LogMsgPtr = StoragePtr<MaxLogLine>;
 
 /// Logger callback function.
@@ -68,8 +67,8 @@ TOOLBOX_API void sys_logger(int level, LogMsgPtr msg, std::size_t size) noexcept
 /// Logger callback function.
 using LogStream = util::OStream<MaxLogLine>;
 
-/// Thread-local log stream. This thread-local instance of OStaticStream can be used to format log
-/// messages before writing to the log.
+/// Thread-local log stream. This thread-local instance of OStream can be used to format log
+/// messages before writing them the log.
 TOOLBOX_API LogStream& log_stream() noexcept;
 
 // Inspired by techniques developed by Rodrigo Fernandes.

--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -53,7 +53,7 @@ string last_msg{};
 void test_logger(int level, LogMsgPtr msg, std::size_t size)
 {
     last_level = level;
-    last_msg.assign(msg->data(), size);
+    last_msg.assign(static_cast<const char*>(msg.get()), size);
 }
 
 } // namespace

--- a/toolbox/util/Allocator.cpp
+++ b/toolbox/util/Allocator.cpp
@@ -20,18 +20,11 @@ namespace toolbox {
 using namespace std;
 
 TOOLBOX_WEAK void* allocate(size_t size);
-TOOLBOX_WEAK void* allocate(size_t size, align_val_t al);
 TOOLBOX_WEAK void deallocate(void* ptr, size_t size) noexcept;
-TOOLBOX_WEAK void deallocate(void* ptr, size_t size, align_val_t al) noexcept;
 
 void* allocate(size_t size)
 {
     return ::operator new(size);
-}
-
-void* allocate(size_t size, align_val_t al)
-{
-    return ::operator new(size, al);
 }
 
 void deallocate(void* ptr, size_t size) noexcept
@@ -40,15 +33,6 @@ void deallocate(void* ptr, size_t size) noexcept
     ::operator delete(ptr, size);
 #else
     ::operator delete(ptr);
-#endif
-}
-
-void deallocate(void* ptr, size_t size, align_val_t al) noexcept
-{
-#if __cpp_sized_deallocation
-    ::operator delete(ptr, size, al);
-#else
-    ::operator delete(ptr, al);
 #endif
 }
 

--- a/toolbox/util/Allocator.hpp
+++ b/toolbox/util/Allocator.hpp
@@ -19,46 +19,25 @@
 
 #include <toolbox/Config.h>
 
-#include <memory>
+#include <new>
 
 namespace toolbox {
 
 TOOLBOX_API void* allocate(std::size_t size);
-TOOLBOX_API void* allocate(std::size_t size, std::align_val_t al);
 TOOLBOX_API void deallocate(void* ptr, std::size_t size) noexcept;
-TOOLBOX_API void deallocate(void* ptr, std::size_t size, std::align_val_t al) noexcept;
 
 inline namespace util {
 
 struct Allocator {
     static void* operator new(std::size_t size) { return allocate(size); }
-    static void* operator new(std::size_t size, std::align_val_t al) { return allocate(size, al); }
     static void operator delete(void* ptr, std::size_t size) noexcept
     {
         return deallocate(ptr, size);
-    }
-    static void operator delete(void* ptr, std::size_t size, std::align_val_t al) noexcept
-    {
-        return deallocate(ptr, size, al);
     }
 
   protected:
     ~Allocator() = default;
 };
-
-using VoidPtr = std::unique_ptr<void, void (*)(void*)>;
-
-template <std::size_t SizeN>
-VoidPtr allocate_unique()
-{
-    return VoidPtr{allocate(SizeN), [](void* ptr) { deallocate(ptr, SizeN); }};
-}
-
-template <std::size_t SizeN, std::align_val_t AlignN>
-VoidPtr allocate_unique()
-{
-    return VoidPtr{allocate(SizeN, AlignN), [](void* ptr) { deallocate(ptr, SizeN, AlignN); }};
-}
 
 } // namespace util
 } // namespace toolbox

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -46,7 +46,7 @@ class StreamBuf final : public std::streambuf {
     /// Constructor for initialising the StreamBuf with a null buffer.
     explicit StreamBuf(std::nullptr_t) noexcept {}
     StreamBuf()
-    : storage_{new Storage<MaxN>}
+    : storage_{make_storage<MaxN>}
     {
         setp(storage_->begin(), storage_->end());
     }
@@ -79,7 +79,8 @@ class StreamBuf final : public std::streambuf {
     {
         storage_.swap(storage);
         if (storage_) {
-            setp(storage_->begin(), storage_->end());
+            auto* const begin = static_cast<char*>(storage_.get());
+            setp(begin, begin + MaxN);
         } else {
             setp(nullptr, nullptr);
         }
@@ -122,10 +123,7 @@ class OStream final : public std::ostream {
     OStream(OStream&&) = delete;
     OStream& operator=(OStream&&) = delete;
 
-    static StoragePtr<MaxN> make_storage()
-    {
-        return std::unique_ptr<Storage<MaxN>>{new Storage<MaxN>};
-    }
+    static StoragePtr<MaxN> make_storage() { return util::make_storage<MaxN>(); }
     const char* data() const noexcept { return buf_.data(); }
     bool empty() const noexcept { return buf_.empty(); }
     std::size_t size() const noexcept { return buf_.size(); }


### PR DESCRIPTION
Replace the Storage class template with a simple void pointer manager by a unique_ptr, where the unique_ptr's deleter encapsulates the allocation size.

Using a class template for the deleter instead of a function pointer also ensures that the unique_ptr has no overhead in terms of its size. I.e. it does not need to store a function pointer.

Remove unused aligned allocator function overloads.

DEV-1325