### PR TITLE
feat: conventional error message format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ runtime_error{"something bad"}` not `throw runtime_error{"Something bad"}`, so t
 below formats without a spurious capital letter mid-message.
 
 ```c++
-TOOLBOX_ERROR << "exception: " << e.what();
+TOOLBOX_ERROR << "exception on main thread: " << e.what();
 ```
 
 ### Logging

--- a/example/EchoClnt.cpp
+++ b/example/EchoClnt.cpp
@@ -76,7 +76,7 @@ class EchoConn {
                 }
             }
         } catch (const std::exception& e) {
-            TOOLBOX_ERROR << "could not read data: " << e.what();
+            TOOLBOX_ERROR << "exception on input: " << e.what();
             dispose(now);
         }
     }
@@ -87,7 +87,7 @@ class EchoConn {
                 throw runtime_error{"partial write"};
             }
         } catch (const std::exception& e) {
-            TOOLBOX_ERROR << "could not write data: " << e.what();
+            TOOLBOX_ERROR << "exception on timer: " << e.what();
             dispose(now);
         }
     }
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
         ret = 0;
 
     } catch (const std::exception& e) {
-        TOOLBOX_ERROR << "exception: " << e.what();
+        TOOLBOX_ERROR << "exception on main thread: " << e.what();
     }
     return ret;
 }

--- a/example/EchoServ.cpp
+++ b/example/EchoServ.cpp
@@ -82,7 +82,7 @@ class EchoConn {
                                       bind<&EchoConn::on_timer>(this));
             }
         } catch (const std::exception& e) {
-            TOOLBOX_ERROR << "exception: " << e.what();
+            TOOLBOX_ERROR << "exception on input: " << e.what();
             dispose(now);
         }
     }
@@ -172,7 +172,7 @@ int main(int argc, char* argv[])
         ret = 0;
 
     } catch (const std::exception& e) {
-        TOOLBOX_ERROR << "exception: " << e.what();
+        TOOLBOX_ERROR << "exception on main thread: " << e.what();
     }
     return ret;
 }

--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
         ret = 0;
 
     } catch (const std::exception& e) {
-        TOOLBOX_ERROR << "exception: " << e.what();
+        TOOLBOX_ERROR << "exception on main thread: " << e.what();
     }
     return ret;
 }

--- a/toolbox/io/Hook.cpp
+++ b/toolbox/io/Hook.cpp
@@ -30,7 +30,7 @@ void dispatch(CyclTime now, const HookList& l) noexcept
         try {
             prev->slot(now);
         } catch (const std::exception& e) {
-            TOOLBOX_ERROR << "error handling hook: " << e.what();
+            TOOLBOX_ERROR << "exception in i/o hook: " << e.what();
         }
     }
 }

--- a/toolbox/io/Reactor.cpp
+++ b/toolbox/io/Reactor.cpp
@@ -160,7 +160,7 @@ int Reactor::dispatch(CyclTime now, Event* buf, int size)
         try {
             ref.slot(now, fd, events);
         } catch (const std::exception& e) {
-            TOOLBOX_ERROR << "error handling io event: " << e.what();
+            TOOLBOX_ERROR << "exception in i/o event handler: " << e.what();
         }
         ++work;
     }

--- a/toolbox/io/Runner.cpp
+++ b/toolbox/io/Runner.cpp
@@ -39,7 +39,7 @@ void run_reactor(Reactor& r, long busy_cycles, ThreadConfig config, const std::a
             }
         }
     } catch (const std::exception& e) {
-        TOOLBOX_CRIT << "exception: " << e.what();
+        TOOLBOX_CRIT << "exception on " << config.name << " thread: " << e.what();
         kill(getpid(), SIGTERM);
     }
     TOOLBOX_NOTICE << "stopping " << config.name << " thread";

--- a/toolbox/io/Timer.cpp
+++ b/toolbox/io/Timer.cpp
@@ -135,7 +135,7 @@ void TimerQueue::expire(CyclTime now)
         // Notify user.
         tmr.slot().invoke(now, tmr);
     } catch (const std::exception& e) {
-        TOOLBOX_ERROR << "error handling timer event: " << e.what();
+        TOOLBOX_ERROR << "exception in i/o timer handler: " << e.what();
     }
 
     // If timer was not cancelled during the callback.

--- a/toolbox/net/Runner.cpp
+++ b/toolbox/net/Runner.cpp
@@ -36,7 +36,7 @@ void run_resolver(Resolver& r, ThreadConfig config)
         while (r.run() >= 0)
             ;
     } catch (const std::exception& e) {
-        TOOLBOX_CRIT << "exception: " << e.what();
+        TOOLBOX_CRIT << "exception on " << config.name << " thread: " << e.what();
         kill(getpid(), SIGTERM);
     }
     TOOLBOX_NOTICE << "stopping " << config.name << " thread";

--- a/toolbox/util/Exception.cpp
+++ b/toolbox/util/Exception.cpp
@@ -28,17 +28,20 @@ Exception::Exception(error_code ec)
 , ec_{ec}
 {
 }
+
 Exception::Exception(int err, const error_category& ecat)
 : Exception{error_code{err, ecat}}
 {
 }
+
 Exception::Exception(error_code ec, std::string_view what)
-: runtime_error{ec.message().append(": ").append(what)}
+: runtime_error{string{what} + ": " + ec.message()}
 , ec_{ec}
 {
 }
+
 Exception::Exception(int err, const error_category& ecat, std::string_view what)
-: Exception(error_code{err, ecat}, what)
+: Exception{error_code{err, ecat}, what}
 {
 }
 

--- a/toolbox/util/Exception.ut.cpp
+++ b/toolbox/util/Exception.ut.cpp
@@ -25,22 +25,22 @@ BOOST_AUTO_TEST_SUITE(ExceptionSuite)
 BOOST_AUTO_TEST_CASE(ExceptionCase)
 {
     const auto ec = std::make_error_code(std::errc::invalid_argument);
-    const Exception e{ec, "foobar error"};
-    BOOST_TEST(e.what() == std::strerror(EINVAL) + std::string{": foobar error"});
+    const Exception e{ec, "cannot send message"};
+    BOOST_TEST(e.what() == std::string{"cannot send message: "} + std::strerror(EINVAL));
     BOOST_TEST(e.code() == ec);
 }
 
 BOOST_AUTO_TEST_CASE(ExceptionToJsonCase)
 {
     const auto ec = std::make_error_code(std::errc::invalid_argument);
-    const Exception e{ec, "foobar error"};
+    const Exception e{ec, "cannot send message"};
 
     std::stringstream ss;
     e.to_json(ss);
 
     BOOST_TEST(ss.str() == //
                "{\"code\":22"
-               ",\"message\":\"Invalid argument: foobar error\""
+               ",\"message\":\"cannot send message: Invalid argument\""
                "}");
 }
 


### PR DESCRIPTION
Standard exception classes such as std::system_error format exception messages such that the "what" argument precedes the error code. Toolbox exceptions should adopt this convention for consistency.

DEV-2766