### PR TITLE
build: improve clang-format check

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Run clang-format
         run: cd build && make clang-format &&
-          [[ -z "$(git status --porcelain)" ]] ||
-            { echo "Please ensure files are formated by running target clang-format"; exit 1; }
+          [[ -z "$(git status -uno --porcelain)" ]] ||
+            { echo "Please ensure files are formatted by running target clang-format"; exit 1; }
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CI build runs clang-format to check that all files are correctly formatted.

Fix a typo in this check and use the Git "-uno" option so that untracked files are ignored when checking for modifications.

DEV-3273