### PR TITLE
chore: add support for project-specific cppcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ find_program(CPPCHECK cppcheck HINTS "${TOOLBOX_TOOLSET}/bin")
 if(CPPCHECK)
   message(STATUS "Found cppcheck")
   cmake_host_system_information(RESULT CORE_COUNT QUERY NUMBER_OF_LOGICAL_CORES)
-  configure_file("${PROJECT_SOURCE_DIR}/cppcheck.sh.in"
+  configure_file("${CMAKE_SOURCE_DIR}/cppcheck.sh.in"
     "${CMAKE_BINARY_DIR}/cppcheck.sh" @ONLY)
   add_custom_target(cppcheck COMMAND bash "${CMAKE_BINARY_DIR}/cppcheck.sh")
 endif()

--- a/etc/cppcheck-suppressions.txt
+++ b/etc/cppcheck-suppressions.txt
@@ -1,9 +1,6 @@
 bufferAccessOutOfBounds:*/toolbox/util/String.ut.cpp
 internalAstError:*/toolbox/io/Disposer.hpp
-preprocessorErrorDirective:*/toolbox/contrib/robin_hood.h
 preprocessorErrorDirective:*/toolbox/net/Error.cpp
 syntaxError:*/toolbox/io/Timer.hpp
-syntaxError:*/toolbox/util/IntTypes.hpp
 syntaxError:*/toolbox/util/StringBuf.hpp
-syntaxError:*/toolbox/util/Version.hpp
 syntaxError:*/toolbox/util/Variant.hpp


### PR DESCRIPTION
Add support for project-specific cppcheck scripts, so that downstream projects can define their own program options.

DEV-3299