### PR TITLE
refactor: rename context types for consistency

### DIFF
--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -134,7 +134,7 @@ endif()
 
 set(lib_bm_SOURCES
   bm/Benchmark.cpp
-  bm/Ctx.cpp
+  bm/Context.cpp
   bm/Range.cpp
   bm/Record.cpp
   bm/Suite.cpp

--- a/toolbox/bm.hpp
+++ b/toolbox/bm.hpp
@@ -17,7 +17,7 @@
 #define TOOLBOX_BM_HPP
 
 #include "bm/Benchmark.hpp"
-#include "bm/Ctx.hpp"
+#include "bm/Context.hpp"
 #include "bm/Range.hpp"
 #include "bm/Record.hpp"
 #include "bm/Suite.hpp"

--- a/toolbox/bm/Benchmark.cpp
+++ b/toolbox/bm/Benchmark.cpp
@@ -79,7 +79,7 @@ class BenchmarkStore {
 };
 } // namespace
 
-Benchmark::Benchmark(const char* name, void (*fn)(BenchmarkCtx&))
+Benchmark::Benchmark(const char* name, void (*fn)(Context&))
 : name{name}
 , fn{fn}
 {

--- a/toolbox/bm/Benchmark.hpp
+++ b/toolbox/bm/Benchmark.hpp
@@ -19,12 +19,12 @@
 #include <toolbox/Config.h>
 
 namespace toolbox::bm {
-class BenchmarkCtx;
+class Context;
 
 struct TOOLBOX_API Benchmark {
-    Benchmark(const char* name, void (*fn)(BenchmarkCtx&));
+    Benchmark(const char* name, void (*fn)(Context&));
     const char* const name;
-    void (*fn)(BenchmarkCtx&);
+    void (*fn)(Context&);
 };
 
 namespace detail {
@@ -34,10 +34,10 @@ TOOLBOX_API int main(int argc, char* argv[]);
 
 #define TOOLBOX_BENCHMARK(NAME)                                                                    \
     namespace benchmark::NAME {                                                                    \
-    void fn(::toolbox::bm::BenchmarkCtx& ctx);                                                     \
+    void fn(::toolbox::bm::Context& ctx);                                                          \
     ::toolbox::bm::Benchmark bm{#NAME, fn};                                                        \
     }                                                                                              \
-    void benchmark::NAME::fn(toolbox::bm::BenchmarkCtx& ctx)
+    void benchmark::NAME::fn(toolbox::bm::Context& ctx)
 
 #define TOOLBOX_BENCHMARK_MAIN                                                                     \
     int main(int argc, char* argv[]) { return toolbox::bm::detail::main(argc, argv); }

--- a/toolbox/bm/Context.cpp
+++ b/toolbox/bm/Context.cpp
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "Ctx.hpp"
+#include "Context.hpp"
 
 namespace toolbox::bm {
 using namespace std;
-BenchmarkCtx::~BenchmarkCtx() = default;
+Context::~Context() = default;
 } // namespace toolbox::bm

--- a/toolbox/bm/Context.hpp
+++ b/toolbox/bm/Context.hpp
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TOOLBOX_BM_CTX
-#define TOOLBOX_BM_CTX
+#ifndef TOOLBOX_BM_CONTEXT
+#define TOOLBOX_BM_CONTEXT
 
 #include <toolbox/bm/Range.hpp>
 #include <toolbox/util/Alarm.hpp>
@@ -23,21 +23,21 @@
 
 namespace toolbox::bm {
 
-class TOOLBOX_API BenchmarkCtx {
+class TOOLBOX_API Context {
   public:
-    explicit BenchmarkCtx(Histogram& hist)
+    explicit Context(Histogram& hist)
     : hist_{hist}
     {
     }
-    ~BenchmarkCtx();
+    ~Context();
 
     // Copy.
-    BenchmarkCtx(const BenchmarkCtx&) = delete;
-    BenchmarkCtx& operator=(const BenchmarkCtx&) = delete;
+    Context(const Context&) = delete;
+    Context& operator=(const Context&) = delete;
 
     // Move.
-    BenchmarkCtx(BenchmarkCtx&&) = delete;
-    BenchmarkCtx& operator=(BenchmarkCtx&&) = delete;
+    Context(Context&&) = delete;
+    Context& operator=(Context&&) = delete;
 
     explicit operator bool() const noexcept { return !stop_; }
     BenchmarkRange range(int first, int last) const noexcept { return {hist_, first, last}; }
@@ -52,4 +52,4 @@ class TOOLBOX_API BenchmarkCtx {
 
 } // namespace toolbox::bm
 
-#endif // TOOLBOX_BM_CTX
+#endif // TOOLBOX_BM_CONTEXT

--- a/toolbox/bm/Suite.hpp
+++ b/toolbox/bm/Suite.hpp
@@ -16,7 +16,7 @@
 #ifndef TOOLBOX_BM_SUITE_HPP
 #define TOOLBOX_BM_SUITE_HPP
 
-#include <toolbox/bm/Ctx.hpp>
+#include <toolbox/bm/Context.hpp>
 
 #include <toolbox/hdr/Histogram.hpp>
 
@@ -33,7 +33,7 @@ class TOOLBOX_API BenchmarkSuite {
         constexpr auto duration = 3s;
 
         Histogram hist{1, 1'000'000'000, 5};
-        BenchmarkCtx ctx{hist};
+        Context ctx{hist};
         Alarm alarm{duration, [&ctx]() { ctx.stop(); }};
         fn(ctx);
         report(name, hist);


### PR DESCRIPTION
Rename context types from Ctx to Context for consistency for other projects.

DEV-3307