### PR TITLE
chore: Include the address in DNS resolution error

### DIFF
--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -54,7 +54,8 @@ inline AddrInfoPtr getaddrinfo(const char* node, const char* service, const addr
     addrinfo* ai{nullptr};
     const auto err = ::getaddrinfo(node, service, &hints, &ai);
     if (err != 0) {
-        throw std::system_error{make_gai_error_code(err), "getaddrinfo"};
+        throw std::system_error{make_gai_error_code(err),
+                                "getaddrinfo (" + std::string{node} + ")"};
     }
     return {ai, freeaddrinfo};
 }


### PR DESCRIPTION
Changes the exception message thrown when getaddrinfo fails to resolve
the address to show the address that it was trying to resolve. This in
turn will cause it to show the address in the log.

DEV-3262