### PR TITLE
chore: fix or suppress most warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 # -*- yaml -*-
 ---
 Checks:
-  '-*,bugprone-use-after-move,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,readability-braces-around-statements,readability-deleted-default,readability-identifier-naming,hicpp-*,-hicpp-no-array-decay,-hicpp-no-assembler,-hicpp-signed-bitwise,-hicpp-vararg'
+  '-*,bugprone-use-after-move,modernize-use-nullptr,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,readability-braces-around-statements,readability-deleted-default,readability-identifier-naming,hicpp-*,-hicpp-no-array-decay,-hicpp-no-assembler,-hicpp-signed-bitwise,-hicpp-vararg,-hicpp-avoid-c-arrays'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/toolbox/bm/Benchmark.cpp
+++ b/toolbox/bm/Benchmark.cpp
@@ -28,6 +28,7 @@ using namespace std;
 namespace {
 class BenchmarkStore {
   public:
+    ~BenchmarkStore() noexcept = default;
     // Copy.
     BenchmarkStore(const BenchmarkStore&) = delete;
     BenchmarkStore& operator=(const BenchmarkStore&) = delete;

--- a/toolbox/bm/Range.hpp
+++ b/toolbox/bm/Range.hpp
@@ -43,7 +43,7 @@ class TOOLBOX_API BenchmarkRange {
         }
 
       public:
-        constexpr Iterator(int val) noexcept
+        constexpr explicit Iterator(int val) noexcept
         : val_{val}
         {
         }

--- a/toolbox/bm/Record.hpp
+++ b/toolbox/bm/Record.hpp
@@ -33,7 +33,7 @@ namespace toolbox::bm {
 /// The elapsed time is recorded in the Histogram object during destruction.
 class TOOLBOX_API BenchmarkRecord {
   public:
-    BenchmarkRecord(Histogram& hist, int count = 1) noexcept;
+    BenchmarkRecord(Histogram& hist, int count = 1) noexcept; // NOLINT(hicpp-explicit-conversions)
     ~BenchmarkRecord();
 
     // Copy.

--- a/toolbox/hdr/Histogram.hpp
+++ b/toolbox/hdr/Histogram.hpp
@@ -38,6 +38,7 @@ struct TOOLBOX_API BucketConfig {
     /// and 5 (inclusive).
     BucketConfig(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
                  int significant_figures);
+    ~BucketConfig() noexcept = default;
 
     // Copy.
     BucketConfig(const BucketConfig&) noexcept = default;
@@ -62,9 +63,10 @@ struct TOOLBOX_API BucketConfig {
 /// A High Dynamic Range (HDR) Histogram.
 class TOOLBOX_API Histogram {
   public:
-    Histogram(const BucketConfig& config);
+    explicit Histogram(const BucketConfig& config);
     Histogram(std::int64_t lowest_trackable_value, std::int64_t highest_trackable_value,
               std::int32_t significant_figures);
+    ~Histogram() noexcept = default;
 
     // Copy.
     Histogram(const Histogram&) = default;

--- a/toolbox/hdr/Histogram.ut.cpp
+++ b/toolbox/hdr/Histogram.ut.cpp
@@ -24,7 +24,7 @@ using namespace toolbox;
 BOOST_AUTO_TEST_SUITE(HistogramSuite)
 
 constexpr std::int64_t Lowest{1};
-constexpr std::int64_t Highest{3600ull * 1000 * 1000};
+constexpr std::int64_t Highest{3600ULL * 1000 * 1000};
 constexpr std::int32_t Significant{3};
 constexpr auto TestValueLevel = 4;
 constexpr auto Interval = 10000;

--- a/toolbox/hdr/Iterator.hpp
+++ b/toolbox/hdr/Iterator.hpp
@@ -30,7 +30,7 @@ class TOOLBOX_API Iterator {
     /// Construct iterator.
     ///
     /// \param h The histogram to iterate over.
-    Iterator(const Histogram& h) noexcept;
+    explicit Iterator(const Histogram& h) noexcept;
     virtual ~Iterator();
 
     // Copy.
@@ -135,7 +135,7 @@ class TOOLBOX_API CountAddedIterator : public Iterator {
 /// RecordedIterator is a recorded value iterator.
 class TOOLBOX_API RecordedIterator final : public CountAddedIterator {
   public:
-    RecordedIterator(const Histogram& h);
+    explicit RecordedIterator(const Histogram& h);
     ~RecordedIterator() override = default;
 
     // Copy.

--- a/toolbox/hdr/Iterator.ut.cpp
+++ b/toolbox/hdr/Iterator.ut.cpp
@@ -21,8 +21,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <cmath>
-
 using namespace std;
 using namespace toolbox;
 

--- a/toolbox/http/Parser.hpp
+++ b/toolbox/http/Parser.hpp
@@ -30,7 +30,7 @@ inline namespace http {
 template <typename DerivedT>
 class BasicParser {
   public:
-    explicit BasicParser(Type type) noexcept
+    explicit BasicParser(Type type) noexcept // NOLINT(hicpp-member-init)
     : type_{type}
     {
         // The http_parser_init() function preserves "data".

--- a/toolbox/http/Url.hpp
+++ b/toolbox/http/Url.hpp
@@ -98,6 +98,7 @@ class Url : public BasicUrl<Url> {
     {
         parse();
     }
+    ~Url() noexcept = default;
 
     // Copy.
     Url(const Url&) = default;
@@ -120,6 +121,7 @@ class UrlView : public BasicUrl<UrlView> {
     {
         parse();
     }
+    ~UrlView() noexcept = default;
 
     // Copy.
     UrlView(const UrlView&) noexcept = default;

--- a/toolbox/io/Epoll.hpp
+++ b/toolbox/io/Epoll.hpp
@@ -208,7 +208,7 @@ class Epoll {
     }
     /// Returns the number of file descriptors that are ready, or zero if no file descriptor became
     /// ready during before the operation timed-out.
-    /// The number of file descriptors returnes may include the timer file descriptor,
+    /// The number of file descriptors returned may include the timer file descriptor,
     /// so callers must check for the presence of this descriptor.
     int wait(Event buf[], std::size_t size, MonoTime timeout, std::error_code& ec) noexcept
     {

--- a/toolbox/io/File.hpp
+++ b/toolbox/io/File.hpp
@@ -237,7 +237,7 @@ inline namespace io {
 /// Get file size.
 inline std::size_t file_size(int fd)
 {
-    struct stat st;
+    struct stat st; // NOLINT(hicpp-member-init)
     os::fstat(fd, st);
     return st.st_size;
 }

--- a/toolbox/io/Handle.hpp
+++ b/toolbox/io/Handle.hpp
@@ -32,8 +32,9 @@ class BasicHandle {
 
     static constexpr Id invalid() noexcept { return PolicyT::invalid(); }
 
-    constexpr BasicHandle(std::nullptr_t = nullptr) noexcept {}
-    constexpr BasicHandle(Id id) noexcept
+    constexpr BasicHandle(std::nullptr_t = nullptr) noexcept {
+    }                                     // NOLINT(hicpp-explicit-conversions)
+    constexpr BasicHandle(Id id) noexcept // NOLINT(hicpp-explicit-conversions)
     : id_{id}
     {
     }

--- a/toolbox/io/Hook.hpp
+++ b/toolbox/io/Hook.hpp
@@ -28,7 +28,7 @@ inline namespace io {
 struct Hook
 : boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>> {
     using Slot = BasicSlot<CyclTime>;
-    Hook(Slot slot) noexcept
+    explicit Hook(Slot slot) noexcept
     : slot{slot}
     {
     }

--- a/toolbox/io/Reactor.hpp
+++ b/toolbox/io/Reactor.hpp
@@ -42,7 +42,7 @@ class TOOLBOX_API Reactor : public Waker {
         , sid_{sid}
         {
         }
-        constexpr Handle(std::nullptr_t = nullptr) noexcept {}
+        constexpr Handle(std::nullptr_t = nullptr) noexcept {} // NOLINT(hicpp-explicit-conversions)
         ~Handle() { reset(); }
 
         // Copy.
@@ -114,7 +114,7 @@ class TOOLBOX_API Reactor : public Waker {
     };
 
     explicit Reactor(std::size_t size_hint = 0);
-    ~Reactor();
+    ~Reactor() override;
 
     // Copy.
     Reactor(const Reactor&) = delete;

--- a/toolbox/io/Timer.cpp
+++ b/toolbox/io/Timer.cpp
@@ -18,7 +18,6 @@
 
 #include <toolbox/sys/Log.hpp>
 
-#include <algorithm>
 #include <string>
 
 namespace toolbox {

--- a/toolbox/io/Timer.hpp
+++ b/toolbox/io/Timer.hpp
@@ -55,7 +55,7 @@ class TOOLBOX_API Timer {
     : impl_{impl, false}
     {
     }
-    Timer(std::nullptr_t = nullptr) noexcept {}
+    Timer(std::nullptr_t = nullptr) noexcept {} // NOLINT(hicpp-explicit-conversions)
     ~Timer() = default;
 
     // Copy.
@@ -104,6 +104,7 @@ class TOOLBOX_API TimerPool {
 
   public:
     TimerPool() = default;
+    ~TimerPool() noexcept = default;
 
     // Copy.
     TimerPool(const TimerPool&) = delete;
@@ -139,10 +140,11 @@ class TOOLBOX_API TimerQueue {
   public:
     /// Implicit conversion from pool is allowed, so that TimerQueue arrays can be aggregate
     /// initialised.
-    TimerQueue(TimerPool& pool)
+    TimerQueue(TimerPool& pool) // NOLINT(hicpp-explicit-conversions)
     : pool_{pool}
     {
     }
+    ~TimerQueue() noexcept = default;
 
     // Copy.
     TimerQueue(const TimerQueue&) = delete;

--- a/toolbox/net/Endpoint.cpp
+++ b/toolbox/net/Endpoint.cpp
@@ -33,7 +33,7 @@ pair<string, string> split_ip_addr(const string& addr, char delim)
         node = addr.substr(0, pos);
         service = addr.substr(pos + 1);
     }
-    // Remove square braces arround ipv6 address.
+    // Remove square braces around ipv6 address.
     if (node.size() >= 2 && node.front() == '[' && node.back() == ']') {
         node = node.substr(1, node.size() - 2);
     }

--- a/toolbox/net/McastSock.hpp
+++ b/toolbox/net/McastSock.hpp
@@ -25,7 +25,7 @@ namespace toolbox {
 inline namespace net {
 
 struct TOOLBOX_API IpMcastGroup {
-    IpMcastGroup(const IpAddr& addr, unsigned ifindex = 0) noexcept;
+    explicit IpMcastGroup(const IpAddr& addr, unsigned ifindex = 0) noexcept;
 
     IpMcastGroup(const IpAddr& addr, const char* ifname, std::error_code& ec) noexcept
     : IpMcastGroup(addr, os::if_nametoindex(ifname, ec))

--- a/toolbox/net/Runner.cpp
+++ b/toolbox/net/Runner.cpp
@@ -33,8 +33,9 @@ void run_resolver(Resolver& r, ThreadConfig config)
         // Reset the resolver before entering the run loop.
         r.reset();
         // The run() function returns -1 when resolver is closed.
-        while (r.run() >= 0)
-            ;
+        while (r.run() >= 0) {
+        }
+
     } catch (const std::exception& e) {
         TOOLBOX_CRIT << "exception on " << config.name << " thread: " << e.what();
         kill(getpid(), SIGTERM);

--- a/toolbox/sys/Log.cpp
+++ b/toolbox/sys/Log.cpp
@@ -99,7 +99,7 @@ void write_log(int level, LogMsgPtr msg, std::size_t size) noexcept
     acquire_logger()(level, move(msg), size);
 }
 
-void null_logger(int, LogMsgPtr, std::size_t) noexcept {}
+void null_logger(int /*unused*/, LogMsgPtr /*unused*/, std::size_t /*unused*/) noexcept {}
 
 void std_logger(int level, LogMsgPtr msg, std::size_t size) noexcept
 {
@@ -107,7 +107,7 @@ void std_logger(int level, LogMsgPtr msg, std::size_t size) noexcept
     const auto t = WallClock::to_time_t(now);
     const auto ms = ms_since_epoch(now);
 
-    struct tm tm;
+    struct tm tm; // NOLINT(hicpp-member-init)
     localtime_r(&t, &tm);
 
     // The following format has an upper-bound of 42 characters:

--- a/toolbox/sys/Thread.hpp
+++ b/toolbox/sys/Thread.hpp
@@ -26,7 +26,7 @@ inline namespace sys {
 
 /// ThreadConfig holds the thread attributes.
 struct ThreadConfig {
-    ThreadConfig(std::string name, std::string affinity = {},
+    ThreadConfig(std::string name, std::string affinity = {}, // NOLINT(hicpp-explicit-conversions)
                  std::string sched_policy = {}) noexcept
     : name{std::move(name)}
     , affinity{std::move(affinity)}
@@ -34,6 +34,7 @@ struct ThreadConfig {
     {
     }
     ThreadConfig() noexcept = default;
+    ~ThreadConfig() noexcept = default;
 
     // Copy.
     ThreadConfig(const ThreadConfig&) = default;

--- a/toolbox/sys/Time.cpp
+++ b/toolbox/sys/Time.cpp
@@ -24,7 +24,7 @@ TOOLBOX_WEAK Nanos get_time(clockid_t clock_id) noexcept;
 
 NanoTime get_time(clockid_t clock_id) noexcept
 {
-    timespec ts;
+    timespec ts; // NOLINT(hicpp-member-init)
     clock_gettime(clock_id, &ts);
     // Long-long literal is required here for ARM32.
     return NanoTime{ts.tv_sec * 1'000'000'000LL + ts.tv_nsec};

--- a/toolbox/sys/Time.hpp
+++ b/toolbox/sys/Time.hpp
@@ -26,7 +26,7 @@
 #include <iosfwd>
 #include <optional>
 
-#include <sys/time.h>
+#include <ctime>
 
 namespace toolbox {
 inline namespace sys {

--- a/toolbox/util/Array.hpp
+++ b/toolbox/util/Array.hpp
@@ -36,7 +36,7 @@ class ArrayView {
     using value_type = ValueT;
 
     using pointer = const ValueT*;
-    using const_pointer = const ValueT*;
+    using const_pointer [[maybe_unused]] = const ValueT*;
 
     using reference = const ValueT&;
     using const_reference = const ValueT&;
@@ -44,7 +44,7 @@ class ArrayView {
     using iterator = const ValueT*;
     using const_iterator = const ValueT*;
 
-    using reverse_iterator = std::reverse_iterator<iterator>;
+    using reverse_iterator [[maybe_unused]] = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     using difference_type = std::ptrdiff_t;
@@ -56,12 +56,12 @@ class ArrayView {
     {
     }
     template <typename TypeU, std::size_t SizeN>
-    constexpr ArrayView(TypeU (&arr)[SizeN]) noexcept
+    constexpr ArrayView(TypeU (&arr)[SizeN]) noexcept // NOLINT(hicpp-explicit-conversions)
     : len_{SizeN}
     , ptr_{arr}
     {
     }
-    ArrayView(const std::vector<ValueT>& arr) noexcept
+    ArrayView(const std::vector<ValueT>& arr) noexcept // NOLINT(hicpp-explicit-conversions)
     : len_{arr.size()}
     , ptr_{arr.empty() ? nullptr : &arr[0]}
     {

--- a/toolbox/util/Options.hpp
+++ b/toolbox/util/Options.hpp
@@ -110,7 +110,7 @@ class Value : public Presence<Value> {
 
 class Switch : public Presence<Switch> {
   public:
-    Switch(bool& flag)
+    Switch(bool& flag) // NOLINT(hicpp-explicit-conversions)
     : flag_{flag}
     {
     }

--- a/toolbox/util/Slot.hpp
+++ b/toolbox/util/Slot.hpp
@@ -35,7 +35,7 @@ class BasicSlot {
     {
         return !(lhs == rhs);
     }
-    constexpr BasicSlot(std::nullptr_t = nullptr) noexcept {}
+    constexpr explicit BasicSlot(std::nullptr_t = nullptr) noexcept {}
     ~BasicSlot() = default;
 
     // Copy.

--- a/toolbox/util/Stream.cpp
+++ b/toolbox/util/Stream.cpp
@@ -21,7 +21,7 @@ inline namespace util {
 using namespace std;
 namespace detail {
 
-ostream& operator<<(ostream& os, ResetState) noexcept
+ostream& operator<<(ostream& os, ResetState /*unused*/) noexcept
 {
     os.clear();
     os.fill(os.widen(' '));

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -193,7 +193,10 @@ class OStaticStream final : public std::ostream {
     std::size_t size() const noexcept { return buf_.size(); }
 
     std::string_view str() const noexcept { return buf_.str(); }
-    operator std::string_view() const noexcept { return buf_.str(); }
+    operator std::string_view() const noexcept
+    {
+        return buf_.str();
+    } // NOLINT(hicpp-explicit-conversions)
     /// Reset the current position back to the beginning of the buffer.
     void reset() noexcept { buf_.reset(); };
 

--- a/toolbox/util/StringBuf.hpp
+++ b/toolbox/util/StringBuf.hpp
@@ -33,7 +33,7 @@ class StringBuf {
     {
         assign(rhs.data(), rhs.size());
     }
-    StringBuf(std::string_view rhs) noexcept { assign(rhs.data(), rhs.size()); }
+    explicit StringBuf(std::string_view rhs) noexcept { assign(rhs.data(), rhs.size()); }
     constexpr StringBuf() noexcept = default;
 
     ~StringBuf() = default;
@@ -114,7 +114,7 @@ class StringBuf {
     auto compare(const char* rdata, std::size_t rlen) const noexcept
     {
         std::strong_ordering result{std::memcmp(buf_, rdata, std::min(size(), rlen)) <=> 0};
-        if (result == 0) {
+        if (result == nullptr) {
             result = size() <=> rlen;
         }
         return result;

--- a/toolbox/util/Utility.hpp
+++ b/toolbox/util/Utility.hpp
@@ -63,8 +63,8 @@ constexpr int hex_digits(UIntegerT i) noexcept
     return 1 + ((Bits - std::countl_zero(i | 1) - 1) >> 2);
 }
 
-static_assert(hex_digits(0x0u) == 1);
-static_assert(hex_digits(0x1u) == 1);
+static_assert(hex_digits(0x0U) == 1);
+static_assert(hex_digits(0x1U) == 1);
 static_assert(hex_digits(std::uint64_t{0xffffffffffff}) == 12);
 
 TOOLBOX_API bool stob(std::string_view sv, bool dfl = false) noexcept;

--- a/toolbox/util/Utility.ut.cpp
+++ b/toolbox/util/Utility.ut.cpp
@@ -132,19 +132,19 @@ BOOST_AUTO_TEST_CASE(Stou64Case)
 
 BOOST_AUTO_TEST_CASE(HexDigitsCase)
 {
-    BOOST_TEST(hex_digits(0x0u) == 1);
-    BOOST_TEST(hex_digits(0x1u) == 1);
-    BOOST_TEST(hex_digits(0xfu) == 1);
-    BOOST_TEST(hex_digits(0x10u) == 2);
-    BOOST_TEST(hex_digits(0xffu) == 2);
+    BOOST_TEST(hex_digits(0x0U) == 1);
+    BOOST_TEST(hex_digits(0x1U) == 1);
+    BOOST_TEST(hex_digits(0xfU) == 1);
+    BOOST_TEST(hex_digits(0x10U) == 2);
+    BOOST_TEST(hex_digits(0xffU) == 2);
 
-    BOOST_TEST(hex_digits(0xcdefu) == 4);
-    BOOST_TEST(hex_digits(0x10000u) == 5);
-    BOOST_TEST(hex_digits(0x89abcdefu) == 8);
-    BOOST_TEST(hex_digits(0x100000000u) == 9);
-    BOOST_TEST(hex_digits(0x567890abcdefu) == 12);
-    BOOST_TEST(hex_digits(0x1000000000000u) == 13);
-    BOOST_TEST(hex_digits(0x1234567890abcdefu) == 16);
+    BOOST_TEST(hex_digits(0xcdefU) == 4);
+    BOOST_TEST(hex_digits(0x10000U) == 5);
+    BOOST_TEST(hex_digits(0x89abcdefU) == 8);
+    BOOST_TEST(hex_digits(0x100000000U) == 9);
+    BOOST_TEST(hex_digits(0x567890abcdefU) == 12);
+    BOOST_TEST(hex_digits(0x1000000000000U) == 13);
+    BOOST_TEST(hex_digits(0x1234567890abcdefU) == 16);
 }
 
 BOOST_AUTO_TEST_CASE(DecDigitsCase)

--- a/toolbox/util/Version.hpp
+++ b/toolbox/util/Version.hpp
@@ -25,7 +25,7 @@ namespace toolbox {
 inline namespace util {
 
 struct Version {
-    constexpr Version(int major = 0, int minor = 0) noexcept
+    constexpr Version(int major = 0, int minor = 0) noexcept // NOLINT(hicpp-explicit-conversions)
     : major{major}
     , minor{minor}
     {


### PR DESCRIPTION
Fixes around 80% of the warnings from clang-tidy mostly through
suppressing false positives using //NOLINT (...) or [[maybe_unused]]
but also fixes a few true positives.

DEV-3349