### PR TITLE
DEV-3384: data race on resolver stop

### DIFF
--- a/toolbox/net/Resolver.cpp
+++ b/toolbox/net/Resolver.cpp
@@ -70,12 +70,6 @@ void Resolver::clear()
     return queue_.clear();
 }
 
-void Resolver::reset()
-{
-    Lock lock{mutex_};
-    stop_ = false;
-}
-
 AddrInfoFuture Resolver::resolve(const std::string& uri, int type)
 {
     Task task{[=]() -> AddrInfoPtr { return parse_endpoint(uri, type); }};

--- a/toolbox/net/Resolver.hpp
+++ b/toolbox/net/Resolver.hpp
@@ -59,9 +59,6 @@ class TOOLBOX_API Resolver {
     /// Clear task queue. Any pending tasks will be cancelled, resulting in a broken promise.
     void clear();
 
-    /// Reset resolver state.
-    void reset();
-
     /// Schedule a URI socket name resolution.
     AddrInfoFuture resolve(const std::string& uri, int type);
 

--- a/toolbox/net/Runner.cpp
+++ b/toolbox/net/Runner.cpp
@@ -30,8 +30,6 @@ void run_resolver(Resolver& r, ThreadConfig config)
     try {
         set_thread_attrs(config);
         TOOLBOX_NOTICE << "started " << config.name << " thread";
-        // Reset the resolver before entering the run loop.
-        r.reset();
         // The run() function returns -1 when resolver is closed.
         while (r.run() >= 0) {
         }


### PR DESCRIPTION
Fix resolver stop data race, and remove reset call in
run_resolver function.

DEV-3384