### PR TITLE
feat: add timestamp parameter to logger

### DIFF
--- a/toolbox/net/Resolver.cpp
+++ b/toolbox/net/Resolver.cpp
@@ -26,7 +26,7 @@ int Resolver::run(Duration timeout)
     constexpr size_t BatchSize = 16;
 
     Lock lock{mutex_};
-    // Predicate returns ​false if the waiting should be continued.
+    // Predicate returns false if the waiting should be continued.
     const auto pred = [this] { return !this->queue_.empty() || stop_; };
     // Returns false if predicate was false after timeout.
     if (!cond_.wait_for(lock, timeout, pred)) {

--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -41,8 +41,9 @@ class Log {
     }
 
   public:
-    explicit Log(LogLevel level) noexcept
-    : level_{level}
+    explicit Log(WallTime ts, LogLevel level) noexcept
+    : ts_{ts}
+    , level_{level}
     , os_{log_stream()}
     {
         os_.set_storage(os_.make_storage());
@@ -50,7 +51,7 @@ class Log {
     ~Log()
     {
         const auto size = os_.size();
-        write_log(level_, os_.release_storage(), size);
+        write_log(ts_, level_, os_.release_storage(), size);
     }
 
     // Copy.
@@ -72,6 +73,7 @@ class Log {
     Log& operator()() noexcept { return *this; }
 
   private:
+    const WallTime ts_;
     const LogLevel level_;
     LogStream& os_;
 };
@@ -80,7 +82,7 @@ class Log {
 } // namespace toolbox
 
 // clang-format off
-#define TOOLBOX_LOG(LEVEL) toolbox::is_log_level(LEVEL) && toolbox::Log{LEVEL}()
+#define TOOLBOX_LOG(LEVEL) toolbox::is_log_level(LEVEL) && toolbox::Log{WallClock::now(), LEVEL}()
 
 #define TOOLBOX_CRIT TOOLBOX_LOG(toolbox::LogLevel::Crit)
 #define TOOLBOX_ERROR TOOLBOX_LOG(toolbox::LogLevel::Error)
@@ -91,7 +93,7 @@ class Log {
 #if TOOLBOX_BUILD_DEBUG
 #define TOOLBOX_DEBUG TOOLBOX_LOG(toolbox::LogLevel::Debug)
 #else
-#define TOOLBOX_DEBUG false && toolbox::Log{toolbox::LogLevel::Debug}()
+#define TOOLBOX_DEBUG false && toolbox::Log{WallClock::now(), toolbox::LogLevel::Debug}()
 #endif
 // clang-format on
 

--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -48,7 +48,7 @@ ostream& operator<<(ostream& os, const Foo<int, int>& val)
 }
 
 struct TestLogger final : Logger {
-    void do_write_log(LogLevel level, LogMsgPtr&& msg, size_t size) noexcept override
+    void do_write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg, size_t size) noexcept override
     {
         last_level = level;
         last_msg.assign(static_cast<const char*>(msg.get()), size);

--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -18,6 +18,7 @@
 #define TOOLBOX_SYS_LOGGER_HPP
 
 #include <toolbox/sys/Limits.hpp>
+#include <toolbox/sys/Time.hpp>
 
 #include <toolbox/util/Storage.hpp>
 
@@ -82,7 +83,7 @@ inline Logger& set_logger(std::nullptr_t) noexcept
 /// Unconditionally write log message to the logger. Specifically, this function does not check that
 /// level is allowed by the current log level; users are expected to call is_log_level() first,
 /// before formatting the log message.
-TOOLBOX_API void write_log(LogLevel level, LogMsgPtr&& msg, std::size_t size) noexcept;
+TOOLBOX_API void write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg, std::size_t size) noexcept;
 
 /// The Logger is implemented by types that may be woken-up, interrupted or otherwise notified
 /// asynchronously.
@@ -99,13 +100,14 @@ class TOOLBOX_API Logger {
     Logger(Logger&&) noexcept = default;
     Logger& operator=(Logger&&) noexcept = default;
 
-    void write_log(LogLevel level, LogMsgPtr&& msg, std::size_t size) noexcept
+    void write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg, std::size_t size) noexcept
     {
-        do_write_log(level, std::move(msg), size);
+        do_write_log(ts, level, std::move(msg), size);
     }
 
   protected:
-    virtual void do_write_log(LogLevel level, LogMsgPtr&& msg, std::size_t size) noexcept = 0;
+    virtual void do_write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg,
+                              std::size_t size) noexcept = 0;
 };
 
 /// ScopedLogger provides a convenient RAII-style utility for setting the backend logger for the


### PR DESCRIPTION
Add a timstamp parameter to the Logger's write_log method. This parameter allows the log time to be captured on the originating thread and passed to a backend logger running on a different thread.

DEV-1325