### PR TITLE
refactor(log)!: Add a 0/None value to log level

### DIFF
--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -63,7 +63,8 @@ BOOST_AUTO_TEST_SUITE(LogSuite)
 
 BOOST_AUTO_TEST_CASE(LogLabelCase)
 {
-    BOOST_TEST(strcmp(log_label(LogLevel{-1}), "CRIT") == 0);
+    BOOST_TEST(strcmp(log_label(LogLevel{-1}), "NONE") == 0);
+    BOOST_TEST(strcmp(log_label(LogLevel::None), "NONE") == 0);
     BOOST_TEST(strcmp(log_label(LogLevel::Crit), "CRIT") == 0);
     BOOST_TEST(strcmp(log_label(LogLevel::Error), "ERROR") == 0);
     BOOST_TEST(strcmp(log_label(LogLevel::Warning), "WARNING") == 0);

--- a/toolbox/sys/Logger.cpp
+++ b/toolbox/sys/Logger.cpp
@@ -33,7 +33,7 @@ inline namespace sys {
 using namespace std;
 namespace {
 
-const char* Labels[] = {"CRIT", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"};
+const char* Labels[] = {"NONE", "CRIT", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"};
 
 // The gettid() function is a Linux-specific function call.
 #if defined(__linux__)
@@ -97,6 +97,8 @@ class SysLogger final : public Logger {
     {
         int prio;
         switch (level) {
+        case LogLevel::None:
+            return;
         case LogLevel::Crit:
             prio = LOG_CRIT;
             break;
@@ -152,7 +154,7 @@ Logger& sys_logger() noexcept
 
 const char* log_label(LogLevel level) noexcept
 {
-    return Labels[static_cast<int>(min(max(level, LogLevel::Crit), LogLevel::Debug))];
+    return Labels[static_cast<int>(min(max(level, LogLevel::None), LogLevel::Debug))];
 }
 
 LogLevel get_log_level() noexcept

--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -29,6 +29,8 @@ inline namespace sys {
 class Logger;
 
 enum class LogLevel : int {
+    /// None.
+    None,
     /// Critical.
     Crit,
     /// Error.


### PR DESCRIPTION
Add a new 0/None enum value to LogLevel so that it has an exceptional
default value. This also increments the value of all previous values.

BREAKING CHANGE: All previous logger levels have had their values
increased by 1