### PR TITLE
chore(build): require boost 1.74 or above

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if(NOT TOOLBOX_BUILD_SHARED)
 endif()
 set(Boost_REALPATH ON)
 
-find_package(Boost 1.67 REQUIRED COMPONENTS date_time unit_test_framework)
+find_package(Boost 1.74 REQUIRED COMPONENTS date_time unit_test_framework)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 install_libraries("${Boost_DATE_TIME_LIBRARY_RELEASE}" "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE}")
 message(STATUS "boost_date_time: ${Boost_DATE_TIME_LIBRARY_RELEASE}")


### PR DESCRIPTION
The C++ build should require boost 1.74 or above because this is version used for official images built by the CI/CD system.

DEV-3425