### PR TITLE
fix(build): undefined reference to unit_test_main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,9 +158,6 @@ include_directories(
   "${PROJECT_SOURCE_DIR}"
   "${CMAKE_BINARY_DIR}/include")
 
-if(NOT TOOLBOX_BUILD_SHARED)
-  set(Boost_USE_STATIC_LIBS ON)
-endif()
 set(Boost_REALPATH ON)
 
 find_package(Boost 1.74 REQUIRED COMPONENTS date_time unit_test_framework)


### PR DESCRIPTION
Statically compiled unit-test applications were failing with the following error:

Main.ut.cpp:(.text.startup+0xd): undefined reference to `boost::unit_test::unit_test_main(bool (*)(), int, char**)' collect2:
error: ld returned 1 exit status

This happens due conflicting use of Boost_USE_STATIC_LIBS and BOOST_TEST_DYN_LINK when shared builds are disabled but boost shared libraries are available. In this case the build sets the BOOST_TEST_DYN_LINK option even though Boost_USE_STATIC_LIBS is also set.

The solution is not to force the use of Boost static libraries, because it leads to more complex and unpredictable build scenarios
with minimal benefit.

DEV-3433