### PR TITLE
fix(build): use of uninitialised value $dlib

### DIFF
--- a/etc/dotdepend.pl
+++ b/etc/dotdepend.pl
@@ -97,6 +97,8 @@ foreach (`$makedepend`) {
     } else {
 
       my ($dcomp, $dlib) = parsedep($_);
+      # Special case for "libutil.h" dependency without a path component.
+      $dlib = 'contrib' unless defined $dlib;
 
       # If component within our library.
       if ($dlib eq $lib) {


### PR DESCRIPTION
Building dependency graph images may result in the following error:

Use of uninitialized value $dlib in string eq at etc/dotdepend.pl line 104.
Use of uninitialized value $_ in concatenation (.) or string at etc/dotdepend.pl line 145.
Error: <stdin>: syntax error in line 29 near ';'

This is because the "libutil.h" dependency may not be prefixed with the path that is used to infer the library to which the dependency belongs.

DEV-3438