### PR TITLE
fix(probe): probes depend on config header

### DIFF
--- a/toolbox/sys/Trace.hpp
+++ b/toolbox/sys/Trace.hpp
@@ -18,6 +18,8 @@
 
 #include <toolbox/util/Finally.hpp>
 
+#include <toolbox/Config.h> // TOOLBOX_HAVE_SYSTEMTAP
+
 #if TOOLBOX_HAVE_SYSTEMTAP
 #ifndef SDT_USE_VARIADIC
 #define SDT_USE_VARIADIC


### PR DESCRIPTION
The Trace.hpp header references the TOOLBOX_HAVE_SYSTEMTAP pre-processor definition so the Config.h must be included.

DEV-3477