### PR TITLE
docs: removing CNAME generation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -35,8 +35,6 @@ if(DOXYGEN_FOUND)
   add_custom_target(tb-doxygen
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     COMMAND "${DOXYGEN_EXECUTABLE}" "${PROJECT_BINARY_DIR}/doc/Doxyfile"
-    COMMAND "${CMAKE_COMMAND}" -E echo toolbox-cpp.reactivemarkets.com
-           >"${PROJECT_BINARY_DIR}/doc/html/CNAME"
     SOURCES "${PROJECT_BINARY_DIR}/doc/Doxyfile")
 
   add_dependencies(tb-doxygen tb-image)


### PR DESCRIPTION
We're now hosting directly on github without a cname.