### PR TITLE
fix(build): error running cppcheck 2.6

### DIFF
--- a/etc/cppcheck-suppressions.txt
+++ b/etc/cppcheck-suppressions.txt
@@ -1,6 +1,8 @@
 bufferAccessOutOfBounds:*/toolbox/util/String.ut.cpp
+cppcheckError:*/toolbox/contrib/robin_hood.h
 internalAstError:*/toolbox/io/Disposer.hpp
 internalAstError:*/toolbox/resp/Parser.hpp
+missingReturn:*/toolbox/util/IntTypes.hpp
 preprocessorErrorDirective:*/toolbox/net/Error.cpp
 syntaxError:*/toolbox/io/Timer.hpp
 syntaxError:*/toolbox/util/StringBuf.hpp


### PR DESCRIPTION
Update cppcheck-suppressions.txt to prevent Cppcheck 2.6 from incorrectly reporting error on valid C++ constructs.

BE-3656