### PR TITLE
fix(http): remove constructor inheritance

### DIFF
--- a/toolbox/http/Exception.hpp
+++ b/toolbox/http/Exception.hpp
@@ -33,9 +33,6 @@ struct TOOLBOX_API Exception : util::Exception {
     {
     }
     ~Exception() override;
-
-  protected:
-    using util::Exception::Exception;
 };
 
 } // namespace http


### PR DESCRIPTION
Allowing the http Exception class to inherit constructors from the base class is error prone because it would allow error_codes to be used with different error categories.

SDB-2875