### PR TITLE
fix(config): config entries cannot be modified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(COMMON_WARN "-Wall -Werror -Wextra -Wstrict-aliasing=2 -Wno-unused-parameter -Wno-unused-variable")
+set(COMMON_WARN "-Wall -Werror -Wextra -Wstrict-aliasing=2 -Wno-unused-parameter -Wno-unused-variable -Wno-error=deprecated-declarations")
 set(COMMON_C_FLAGS "-fstrict-aliasing -fvisibility=hidden")
 set(COMMON_CXX_FLAGS "${COMMON_C_FLAGS} -faligned-new")
 

--- a/toolbox/util/Config.hpp
+++ b/toolbox/util/Config.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -136,7 +136,10 @@ class TOOLBOX_API Config {
     {
         return read_section(is, next);
     }
-    void set(std::string key, std::string val) { map_.emplace(std::move(key), std::move(val)); }
+    void set(std::string key, std::string val)
+    {
+        map_.insert_or_assign(std::move(key), std::move(val));
+    }
     void set_parent(Config& parent) noexcept { parent_ = &parent; }
 
   private:

--- a/toolbox/util/Config.ut.cpp
+++ b/toolbox/util/Config.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,6 +104,25 @@ st = = uv =
     BOOST_TEST(conf["st"] == "= uv =");
     BOOST_TEST(next.empty());
     BOOST_TEST(is.eof());
+}
+
+BOOST_AUTO_TEST_CASE(ConfigSetAndGetCase)
+{
+    Config config;
+
+    BOOST_TEST(config.get<int>("foo", 101) == 101);
+    BOOST_TEST(config.get<int>("bar", 202) == 202);
+
+    config.set("foo", "101");
+    config.set("bar", "202");
+
+    BOOST_TEST(config.get<int>("foo", 0) == 101);
+    BOOST_TEST(config.get<int>("bar", 0) == 202);
+
+    config.set("foo", "303");
+
+    BOOST_TEST(config.get<int>("foo", 0) == 303);
+    BOOST_TEST(config.get<int>("bar", 0) == 202);
 }
 
 BOOST_AUTO_TEST_CASE(ConfigOverrideCase)


### PR DESCRIPTION
The Config set method is not updating existing entries.
The insert_or_assign method should be used on the underlying map instead of emplace.

SDB-2935