### PR TITLE
chore(sys): change date time formatting for stdlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 /.idea/
 *.kdev4
 
+# LSP.
+.clangd/
+.cache/clangd
+compile_commands.json
+
 # OSX.
 .DS_Store
 


### PR DESCRIPTION
Changes the formatting for date and time for stdlog to be consistent
with Go logging, this also increases the accuracy of the time to
microseconds.

SDB-3132