### PR TITLE
chore: fix unused includes and increase constexpr use

### DIFF
--- a/example/EchoClnt.cpp
+++ b/example/EchoClnt.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 #include <toolbox/net.hpp>
 #include <toolbox/sys.hpp>
 #include <toolbox/util.hpp>
-
-#include <boost/intrusive/list.hpp>
 
 using namespace std;
 using namespace toolbox;

--- a/example/EchoServ.cpp
+++ b/example/EchoServ.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 #include <toolbox/net.hpp>
 #include <toolbox/sys.hpp>
 #include <toolbox/util.hpp>
-
-#include <boost/intrusive/list.hpp>
 
 using namespace std;
 using namespace toolbox;

--- a/toolbox/bm/Context.hpp
+++ b/toolbox/bm/Context.hpp
@@ -1,5 +1,5 @@
 // The Reactive C++ Toolbox.
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 
 #include <toolbox/bm/Range.hpp>
 #include <toolbox/util/Alarm.hpp>
-
-#include <atomic>
 
 namespace toolbox::bm {
 

--- a/toolbox/hdr/Utility.ut.cpp
+++ b/toolbox/hdr/Utility.ut.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 #include "Utility.hpp"
-
 #include "Histogram.hpp"
 #include "Iterator.hpp"
 

--- a/toolbox/http/App.hpp
+++ b/toolbox/http/App.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 #define TOOLBOX_HTTP_APP_HPP
 
 #include <toolbox/http/Conn.hpp>
-#include <toolbox/sys/Time.hpp>
-#include <toolbox/util/Version.hpp>
 
 namespace toolbox {
 inline namespace http {

--- a/toolbox/http/Conn.hpp
+++ b/toolbox/http/Conn.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,13 +21,9 @@
 #include <toolbox/http/Request.hpp>
 #include <toolbox/http/Stream.hpp>
 #include <toolbox/io/Disposer.hpp>
-#include <toolbox/io/Event.hpp>
 #include <toolbox/io/Reactor.hpp>
 #include <toolbox/net/Endpoint.hpp>
 #include <toolbox/net/IoSock.hpp>
-#include <toolbox/util/Allocator.hpp>
-
-#include <boost/intrusive/list.hpp>
 
 namespace toolbox {
 inline namespace http {

--- a/toolbox/http/Parser.hpp
+++ b/toolbox/http/Parser.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,8 @@
 #define TOOLBOX_HTTP_PARSER_HPP
 
 #include <toolbox/http/Exception.hpp>
-#include <toolbox/http/Types.hpp>
 #include <toolbox/io/Buffer.hpp>
 #include <toolbox/sys/Time.hpp>
-
-#include <string_view>
 
 namespace toolbox {
 inline namespace http {

--- a/toolbox/http/Request.hpp
+++ b/toolbox/http/Request.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef TOOLBOX_HTTP_REQUEST_HPP
 #define TOOLBOX_HTTP_REQUEST_HPP
 
-#include <toolbox/http/Types.hpp>
 #include <toolbox/http/Url.hpp>
 
 #include <vector>

--- a/toolbox/http/Serv.hpp
+++ b/toolbox/http/Serv.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef TOOLBOX_HTTP_SERV_HPP
 #define TOOLBOX_HTTP_SERV_HPP
 
-#include <toolbox/http/App.hpp>
 #include <toolbox/http/Conn.hpp>
 #include <toolbox/net/StreamAcceptor.hpp>
 

--- a/toolbox/io/Epoll.hpp
+++ b/toolbox/io/Epoll.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,7 @@
 #define TOOLBOX_IO_EPOLL_HPP
 
 #include <toolbox/io/Event.hpp>
-#include <toolbox/io/Handle.hpp>
 #include <toolbox/io/TimerFd.hpp>
-#include <toolbox/sys/Error.hpp>
-
-#include <sys/epoll.h>
 
 namespace toolbox {
 namespace os {

--- a/toolbox/io/Event.hpp
+++ b/toolbox/io/Event.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 #define TOOLBOX_IO_EVENT_HPP
 
 #include <cstdint>
-#include <type_traits>
 #include <utility>
 
 #include <sys/epoll.h>

--- a/toolbox/io/File.hpp
+++ b/toolbox/io/File.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@
 #include <fcntl.h>
 
 #include <sys/stat.h>
-#include <sys/types.h>
 
 namespace toolbox {
 namespace os {

--- a/toolbox/io/Handle.hpp
+++ b/toolbox/io/Handle.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef TOOLBOX_IO_HANDLE_HPP
 #define TOOLBOX_IO_HANDLE_HPP
 
-#include <cstddef> // nullptr_t
 #include <utility> // swap<>
 
 #include <unistd.h> // close()

--- a/toolbox/io/Runner.hpp
+++ b/toolbox/io/Runner.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <toolbox/sys/Thread.hpp>
 
-#include <atomic>
 #include <thread>
 
 namespace toolbox {

--- a/toolbox/io/Timer.hpp
+++ b/toolbox/io/Timer.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@
 #include <boost/intrusive_ptr.hpp>
 
 #include <memory>
-#include <vector>
 
 namespace toolbox {
 inline namespace io {

--- a/toolbox/net/Endian.hpp
+++ b/toolbox/net/Endian.hpp
@@ -22,7 +22,6 @@
 #include <bit>
 #include <concepts>
 #include <cstdint>
-#include <type_traits>
 
 namespace toolbox {
 inline namespace net {

--- a/toolbox/net/Frame.hpp
+++ b/toolbox/net/Frame.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@
 #include <toolbox/io/Buffer.hpp>
 
 #include <cassert>
-#include <cstdint>
-#include <string_view>
 
 namespace toolbox {
 inline namespace net {

--- a/toolbox/net/Protocol.hpp
+++ b/toolbox/net/Protocol.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@
 #include <toolbox/Config.h>
 
 #include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
 
 namespace toolbox {
 inline namespace net {

--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,14 +21,9 @@
 
 #include <toolbox/io/File.hpp>
 
-#include <memory>
-
 #include <net/if.h>
 #include <netdb.h>
-#include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <sys/socket.h>
-#include <sys/types.h>
 
 namespace toolbox {
 inline namespace net {

--- a/toolbox/net/StreamAcceptor.hpp
+++ b/toolbox/net/StreamAcceptor.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef TOOLBOX_NET_STREAMACCEPTOR_HPP
 #define TOOLBOX_NET_STREAMACCEPTOR_HPP
 
-#include <toolbox/io/Event.hpp>
 #include <toolbox/io/Reactor.hpp>
 #include <toolbox/net/StreamSock.hpp>
 

--- a/toolbox/net/StreamConnector.hpp
+++ b/toolbox/net/StreamConnector.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef TOOLBOX_NET_STREAMCONNECTOR_HPP
 #define TOOLBOX_NET_STREAMCONNECTOR_HPP
 
-#include <toolbox/io/Event.hpp>
 #include <toolbox/io/Reactor.hpp>
 #include <toolbox/net/StreamSock.hpp>
 

--- a/toolbox/sys/Daemon.hpp
+++ b/toolbox/sys/Daemon.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 #define TOOLBOX_SYS_DAEMON_HPP
 
 #include <toolbox/Config.h>
-
-#include <sys/types.h>
 
 namespace toolbox {
 inline namespace sys {

--- a/toolbox/sys/Date.hpp
+++ b/toolbox/sys/Date.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@
 
 #include <toolbox/sys/Time.hpp>
 #include <toolbox/util/IntTypes.hpp>
-
-#include <cassert>
 
 namespace toolbox {
 inline namespace sys {

--- a/toolbox/sys/Logger.cpp
+++ b/toolbox/sys/Logger.cpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 #include <mutex>
 
 #include <syslog.h>
-#include <unistd.h> // getpid()
 
 #include <sys/uio.h> // writev()
 

--- a/toolbox/sys/Runner.hpp
+++ b/toolbox/sys/Runner.hpp
@@ -21,8 +21,6 @@
 #include <toolbox/sys/Signal.hpp>
 #include <toolbox/sys/Thread.hpp>
 
-#include <thread>
-
 namespace toolbox {
 inline namespace sys {
 

--- a/toolbox/sys/Time.hpp
+++ b/toolbox/sys/Time.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,10 +23,7 @@
 
 #include <chrono>
 #include <iomanip>
-#include <iosfwd>
 #include <optional>
-
-#include <ctime>
 
 namespace toolbox {
 inline namespace sys {

--- a/toolbox/util/Array.hpp
+++ b/toolbox/util/Array.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 #ifndef TOOLBOX_UTIL_ARRAY_HPP
 #define TOOLBOX_UTIL_ARRAY_HPP
 
-#include <cstddef> // ptrdiff_t
-#include <iterator>
 #include <vector>
 
 namespace toolbox {

--- a/toolbox/util/Config.hpp
+++ b/toolbox/util/Config.hpp
@@ -18,7 +18,6 @@
 #define TOOLBOX_UTIL_CONFIG_HPP
 
 #include <toolbox/util/String.hpp>
-#include <toolbox/util/TypeTraits.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
@@ -26,7 +25,6 @@
 #pragma GCC diagnostic pop
 
 #include <map>
-#include <string>
 
 namespace toolbox {
 inline namespace util {

--- a/toolbox/util/Enum.hpp
+++ b/toolbox/util/Enum.hpp
@@ -19,9 +19,6 @@
 
 #include <toolbox/util/Concepts.hpp>
 
-#include <iosfwd>
-#include <type_traits>
-
 namespace toolbox {
 inline namespace util {
 

--- a/toolbox/util/Exception.hpp
+++ b/toolbox/util/Exception.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 #define TOOLBOX_UTIL_EXCEPTION_HPP
 
 #include <toolbox/util/Stream.hpp>
-
-#include <stdexcept>
 
 namespace toolbox {
 inline namespace util {

--- a/toolbox/util/IntTypes.hpp
+++ b/toolbox/util/IntTypes.hpp
@@ -21,12 +21,6 @@
 
 #include <boost/functional/hash.hpp>
 
-#include <compare>
-#include <cstdint>
-#include <iosfwd>
-#include <limits>
-#include <type_traits>
-
 namespace toolbox {
 inline namespace util {
 
@@ -242,7 +236,10 @@ struct TOOLBOX_PACKED IntWrapper {
     // Stream.
 
     /// Insertion.
-    friend constexpr std::ostream& operator<<(std::ostream& os, IntWrapper rhs) { return os << rhs.value_; }
+    friend constexpr std::ostream& operator<<(std::ostream& os, IntWrapper rhs)
+    {
+        return os << rhs.value_;
+    }
 
   private:
     ValueType value_;

--- a/toolbox/util/IntTypes.hpp
+++ b/toolbox/util/IntTypes.hpp
@@ -71,70 +71,70 @@ struct TOOLBOX_PACKED IntWrapper {
     // Assignment.
 
     /// Addition assignment.
-    IntWrapper& operator+=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator+=(IntWrapper rhs) noexcept
     {
         value_ += rhs.value_;
         return *this;
     }
 
     /// Subtraction assignment.
-    IntWrapper& operator-=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator-=(IntWrapper rhs) noexcept
     {
         value_ -= rhs.value_;
         return *this;
     }
 
     /// Multiplication assignment.
-    IntWrapper& operator*=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator*=(IntWrapper rhs) noexcept
     {
         value_ *= rhs.value_;
         return *this;
     }
 
     /// Division assignment.
-    IntWrapper& operator/=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator/=(IntWrapper rhs) noexcept
     {
         value_ /= rhs.value_;
         return *this;
     }
 
     /// Modulo assignment.
-    IntWrapper& operator%=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator%=(IntWrapper rhs) noexcept
     {
         value_ %= rhs.value_;
         return *this;
     }
 
     /// Bitwise AND assignment.
-    IntWrapper& operator&=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator&=(IntWrapper rhs) noexcept
     {
         value_ &= rhs.value_;
         return *this;
     }
 
     /// Bitwise OR assignment.
-    IntWrapper& operator|=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator|=(IntWrapper rhs) noexcept
     {
         value_ |= rhs.value_;
         return *this;
     }
 
     /// Bitwise XOR assignment.
-    IntWrapper& operator^=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator^=(IntWrapper rhs) noexcept
     {
         value_ ^= rhs.value_;
         return *this;
     }
 
     /// Bitwise left shift assignment.
-    IntWrapper& operator<<=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator<<=(IntWrapper rhs) noexcept
     {
         value_ <<= rhs.value_;
         return *this;
     }
 
     /// Bitwise right shift assignment.
-    IntWrapper& operator>>=(IntWrapper rhs) noexcept
+    constexpr IntWrapper& operator>>=(IntWrapper rhs) noexcept
     {
         value_ >>= rhs.value_;
         return *this;
@@ -143,24 +143,24 @@ struct TOOLBOX_PACKED IntWrapper {
     // Increment/Decrement.
 
     /// Pre-increment.
-    IntWrapper& operator++() noexcept
+    constexpr IntWrapper& operator++() noexcept
     {
         ++value_;
         return *this;
     }
 
     /// Pre-decrement.
-    IntWrapper& operator--() noexcept
+    constexpr IntWrapper& operator--() noexcept
     {
         --value_;
         return *this;
     }
 
     /// Post-increment.
-    IntWrapper operator++(int) noexcept { return IntWrapper{value_++}; }
+    constexpr IntWrapper operator++(int) noexcept { return IntWrapper{value_++}; }
 
     /// Post-decrement.
-    IntWrapper operator--(int) noexcept { return IntWrapper{value_--}; }
+    constexpr IntWrapper operator--(int) noexcept { return IntWrapper{value_--}; }
 
     // Arithmetic.
 
@@ -236,13 +236,13 @@ struct TOOLBOX_PACKED IntWrapper {
     }
 
     // Comparison.
-    constexpr auto operator<=>(const IntWrapper&) const noexcept = default;
-    constexpr bool operator==(const IntWrapper&) const noexcept = default;
+    friend constexpr auto operator<=>(const IntWrapper&, const IntWrapper&) noexcept = default;
+    friend constexpr bool operator==(const IntWrapper&, const IntWrapper&) noexcept = default;
 
     // Stream.
 
     /// Insertion.
-    friend std::ostream& operator<<(std::ostream& os, IntWrapper rhs) { return os << rhs.value_; }
+    friend constexpr std::ostream& operator<<(std::ostream& os, IntWrapper rhs) { return os << rhs.value_; }
 
   private:
     ValueType value_;

--- a/toolbox/util/Math.hpp
+++ b/toolbox/util/Math.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <toolbox/Config.h>
 
-#include <algorithm>
 #include <bit>
 #include <cmath>
 

--- a/toolbox/util/Options.hpp
+++ b/toolbox/util/Options.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,10 +28,8 @@
 #include <toolbox/util/RefCount.hpp>
 #include <toolbox/util/String.hpp>
 
-#include <functional>
 #include <map>
 #include <variant>
-#include <vector>
 
 namespace toolbox {
 inline namespace util {

--- a/toolbox/util/RefCount.hpp
+++ b/toolbox/util/RefCount.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 #ifndef TOOLBOX_UTIL_REFCOUNT_HPP
 #define TOOLBOX_UTIL_REFCOUNT_HPP
-
-#include <toolbox/Config.h>
 
 #include <boost/intrusive_ptr.hpp>
 

--- a/toolbox/util/Slot.hpp
+++ b/toolbox/util/Slot.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 #define TOOLBOX_UTIL_SLOT_HPP
 
 #include <toolbox/util/Traits.hpp>
-
-#include <utility>
 
 namespace toolbox {
 inline namespace util {

--- a/toolbox/util/Storage.hpp
+++ b/toolbox/util/Storage.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <toolbox/util/Allocator.hpp>
 
-#include <iterator>
 #include <memory>
 
 namespace toolbox {

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -21,9 +21,6 @@
 
 #include <experimental/iterator>
 
-#include <ostream>
-#include <string_view>
-
 namespace toolbox {
 inline namespace util {
 namespace detail {

--- a/toolbox/util/StreamInserter.hpp
+++ b/toolbox/util/StreamInserter.hpp
@@ -16,8 +16,6 @@
 #ifndef TOOLBOX_UTIL_STREAMINSERTER_HPP
 #define TOOLBOX_UTIL_STREAMINSERTER_HPP
 
-#include <concepts>
-#include <iosfwd>
 #include <utility>
 
 namespace toolbox {

--- a/toolbox/util/String.hpp
+++ b/toolbox/util/String.hpp
@@ -17,6 +17,7 @@
 #ifndef TOOLBOX_UTIL_STRING_HPP
 #define TOOLBOX_UTIL_STRING_HPP
 
+#include <toolbox/util/Concepts.hpp>
 #include <toolbox/util/TypeTraits.hpp>
 
 #include <charconv>

--- a/toolbox/util/StringBuf.hpp
+++ b/toolbox/util/StringBuf.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef TOOLBOX_UTIL_STRINGBUF_HPP
 #define TOOLBOX_UTIL_STRINGBUF_HPP
 
-#include <compare>
 #include <cstring>
 #include <string_view>
 

--- a/toolbox/util/Tokeniser.hpp
+++ b/toolbox/util/Tokeniser.hpp
@@ -1,6 +1,6 @@
 // The Reactive C++ Toolbox.
 // Copyright (C) 2013-2019 Swirly Cloud Limited
-// Copyright (C) 2021 Reactive Markets Limited
+// Copyright (C) 2022 Reactive Markets Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,19 +27,19 @@ inline namespace util {
 
 class Tokeniser {
   public:
-    Tokeniser(std::string_view buf, std::string_view delims) noexcept { reset(buf, delims); }
-    Tokeniser() noexcept { reset(""sv, ""sv); }
-    ~Tokeniser() = default;
+    constexpr Tokeniser(std::string_view buf, std::string_view delims) noexcept { reset(buf, delims); }
+    constexpr Tokeniser() noexcept { reset(""sv, ""sv); }
+    constexpr ~Tokeniser() = default;
 
     // Copy.
-    Tokeniser(const Tokeniser&) noexcept = default;
-    Tokeniser& operator=(const Tokeniser&) noexcept = default;
+    constexpr Tokeniser(const Tokeniser&) noexcept = default;
+    constexpr Tokeniser& operator=(const Tokeniser&) noexcept = default;
 
     // Move.
-    Tokeniser(Tokeniser&&) noexcept = default;
-    Tokeniser& operator=(Tokeniser&&) noexcept = default;
+    constexpr Tokeniser(Tokeniser&&) noexcept = default;
+    constexpr Tokeniser& operator=(Tokeniser&&) noexcept = default;
 
-    void reset(std::string_view buf, std::string_view delims) noexcept
+    constexpr void reset(std::string_view buf, std::string_view delims) noexcept
     {
         buf_ = buf;
         delims_ = delims;
@@ -47,19 +47,19 @@ class Tokeniser {
         j_ = std::find_first_of(i_, buf_.cend(), delims_.cbegin(), delims_.cend());
     }
     /// Returns total bytes consumed.
-    std::size_t consumed() const noexcept { return i_ - buf_.cbegin(); }
+    constexpr std::size_t consumed() const noexcept { return i_ - buf_.cbegin(); }
     /// Returns true if all bytes have been consumed.
-    bool empty() const noexcept { return i_ == buf_.cend(); }
+    constexpr bool empty() const noexcept { return i_ == buf_.cend(); }
     /// Returns true if a delimiter was found in the remaining data.
-    bool has_delim() const noexcept { return j_ != buf_.cend(); }
-    std::string_view top() const noexcept { return buf_.substr(i_ - buf_.cbegin(), j_ - i_); }
-    std::string_view next() noexcept
+    constexpr bool has_delim() const noexcept { return j_ != buf_.cend(); }
+    constexpr std::string_view top() const noexcept { return buf_.substr(i_ - buf_.cbegin(), j_ - i_); }
+    constexpr std::string_view next() noexcept
     {
         const auto tok = top();
         pop();
         return tok;
     }
-    void pop() noexcept
+    constexpr void pop() noexcept
     {
         if (j_ != buf_.cend()) {
             i_ = j_ + 1;
@@ -77,7 +77,7 @@ class Tokeniser {
 };
 
 template <typename FnT>
-std::size_t parse_line(std::string_view buf, FnT fn)
+constexpr std::size_t parse_line(std::string_view buf, FnT fn)
 {
     Tokeniser lines{buf, "\n"sv};
     while (lines.has_delim()) {
@@ -91,7 +91,7 @@ template <std::size_t N>
 using Row = std::array<std::string_view, N>;
 
 template <std::size_t N>
-void split(std::string_view line, std::string_view delims, Row<N>& row) noexcept
+constexpr void split(std::string_view line, std::string_view delims, Row<N>& row) noexcept
 {
     Tokeniser toks{line, delims};
     for (auto& col : row) {

--- a/toolbox/util/Tokeniser.hpp
+++ b/toolbox/util/Tokeniser.hpp
@@ -27,7 +27,10 @@ inline namespace util {
 
 class Tokeniser {
   public:
-    constexpr Tokeniser(std::string_view buf, std::string_view delims) noexcept { reset(buf, delims); }
+    constexpr Tokeniser(std::string_view buf, std::string_view delims) noexcept
+    {
+        reset(buf, delims);
+    }
     constexpr Tokeniser() noexcept { reset(""sv, ""sv); }
     constexpr ~Tokeniser() = default;
 
@@ -52,7 +55,10 @@ class Tokeniser {
     constexpr bool empty() const noexcept { return i_ == buf_.cend(); }
     /// Returns true if a delimiter was found in the remaining data.
     constexpr bool has_delim() const noexcept { return j_ != buf_.cend(); }
-    constexpr std::string_view top() const noexcept { return buf_.substr(i_ - buf_.cbegin(), j_ - i_); }
+    constexpr std::string_view top() const noexcept
+    {
+        return buf_.substr(i_ - buf_.cbegin(), j_ - i_);
+    }
     constexpr std::string_view next() noexcept
     {
         const auto tok = top();

--- a/toolbox/util/Utility.hpp
+++ b/toolbox/util/Utility.hpp
@@ -18,12 +18,9 @@
 #define TOOLBOX_UTIL_UTILITY_HPP
 
 #include <toolbox/Config.h>
-#include <toolbox/util/Concepts.hpp>
 
 #include <bit>
-#include <cstdint>
 #include <string_view>
-#include <type_traits>
 
 namespace toolbox {
 inline namespace util {


### PR DESCRIPTION
Includes two commits:
* Fixing a range of includes (mostly removing redundant ones, but some have been rearranged)
* Adding constexpr to a couple types.