### PR TITLE
fix: iterator invalidation reading config

### DIFF
--- a/toolbox/util/Config.hpp
+++ b/toolbox/util/Config.hpp
@@ -142,7 +142,7 @@ class TOOLBOX_API Config {
 
   private:
     std::istream& read_section(std::istream& is, std::string* next);
-    boost::container::flat_map<std::string, std::string> map_;
+    std::map<std::string, std::string> map_;
     Config* parent_{nullptr};
 };
 


### PR DESCRIPTION
get returns a string_view to an iterator which is invalidated if set is called. Changing to a map as it doesn't invalidate iterators

SDB-3803