### PR TITLE
feat(net): ensure that Nagle is always disabled

### DIFF
--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -675,6 +675,22 @@ inline int get_so_snd_buf(int sockfd)
     return optval;
 }
 
+inline bool is_tcp_no_delay(int sockfd, std::error_code& ec) noexcept
+{
+    int optval{};
+    socklen_t optlen{sizeof(optval)};
+    os::getsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, optlen, ec);
+    return optval != 0;
+}
+
+inline bool is_tcp_no_delay(int sockfd)
+{
+    int optval{};
+    socklen_t optlen{sizeof(optval)};
+    os::getsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, optlen);
+    return optval != 0;
+}
+
 inline void set_so_rcv_buf(int sockfd, int size, std::error_code& ec) noexcept
 {
     os::setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size), ec);
@@ -791,6 +807,11 @@ struct Sock : FileHandle {
     }
     int get_snd_buf() const { return toolbox::get_so_snd_buf(get()); }
 
+    bool is_tcp_no_delay(std::error_code& ec) const noexcept
+    {
+        return toolbox::is_tcp_no_delay(get(), ec);
+    }
+    bool is_tcp_no_delay() const { return toolbox::is_tcp_no_delay(get()); }
     void close() { reset(); }
 
     void set_non_block(std::error_code& ec) noexcept { toolbox::set_non_block(get(), ec); }

--- a/toolbox/net/StreamAcceptor.hpp
+++ b/toolbox/net/StreamAcceptor.hpp
@@ -58,6 +58,9 @@ class StreamAcceptor {
         sock.set_non_block();
         if (sock.is_ip_family()) {
             set_tcp_no_delay(sock.get(), true);
+            if (!is_tcp_no_delay(sock.get())) {
+                throw std::runtime_error{"TCP_NODELAY option not set"};
+            }
         }
         static_cast<DerivedT*>(this)->on_sock_accept(now, std::move(sock), ep);
     }

--- a/toolbox/net/StreamConnector.hpp
+++ b/toolbox/net/StreamConnector.hpp
@@ -50,6 +50,9 @@ class StreamConnector {
         sock.set_non_block();
         if (sock.is_ip_family()) {
             set_tcp_no_delay(sock.get(), true);
+            if (!is_tcp_no_delay(sock.get())) {
+                throw std::runtime_error{"TCP_NODELAY option not set"};
+            }
         }
 
         std::error_code ec;


### PR DESCRIPTION
Perform a runtime check to ensure that the Nagle is disabled, and throw an exception if it is not.

SDB-3832