### PR TITLE
fix(log): acquire thread-id on caller thread

### DIFF
--- a/bench/Log.bm.cpp
+++ b/bench/Log.bm.cpp
@@ -42,7 +42,8 @@ class FileLogger final : public Logger {
     }
 
   private:
-    void do_write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg, size_t size) noexcept override
+    void do_write_log(WallTime ts, LogLevel level, int tid, LogMsgPtr&& msg,
+                      size_t size) noexcept override
     {
         os::write(*fh_, msg.get(), size);
     }

--- a/toolbox/bm/Benchmark.hpp
+++ b/toolbox/bm/Benchmark.hpp
@@ -40,6 +40,9 @@ TOOLBOX_API int main(int argc, char* argv[]);
     void benchmark::NAME::fn(toolbox::bm::Context& ctx)
 
 #define TOOLBOX_BENCHMARK_MAIN                                                                     \
-    int main(int argc, char* argv[]) { return toolbox::bm::detail::main(argc, argv); }
+    int main(int argc, char* argv[])                                                               \
+    {                                                                                              \
+        return toolbox::bm::detail::main(argc, argv);                                              \
+    }
 
 #endif // TOOLBOX_BM_BENCHMARK_HPP

--- a/toolbox/sys/Date.hpp
+++ b/toolbox/sys/Date.hpp
@@ -23,10 +23,8 @@
 namespace toolbox {
 inline namespace sys {
 
-struct IsoDatePolicy : Int32Policy {
-};
-struct JDayPolicy : Int32Policy {
-};
+struct IsoDatePolicy : Int32Policy {};
+struct JDayPolicy : Int32Policy {};
 
 /// ISO8601 date in yyymmdd format.
 using IsoDate = IntWrapper<IsoDatePolicy>;

--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -45,13 +45,16 @@ class Log {
     : ts_{ts}
     , level_{level}
     , os_{log_stream()}
+    , flags_{os_.flags()}
     {
         os_.set_storage(os_.make_storage());
     }
     ~Log()
     {
-        const auto size = os_.size();
+        const auto size{os_.size()};
         write_log(ts_, level_, os_.release_storage(), size);
+        // Restore saved flags.
+        os_.flags(flags_);
     }
 
     // Copy.
@@ -76,6 +79,7 @@ class Log {
     const WallTime ts_;
     const LogLevel level_;
     LogStream& os_;
+    const std::ios::fmtflags flags_;
 };
 
 } // namespace sys

--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -48,7 +48,8 @@ ostream& operator<<(ostream& os, const Foo<int, int>& val)
 }
 
 struct TestLogger final : Logger {
-    void do_write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg, size_t size) noexcept override
+    void do_write_log(WallTime ts, LogLevel level, int tid, LogMsgPtr&& msg,
+                      size_t size) noexcept override
     {
         last_level = level;
         last_msg.assign(static_cast<const char*>(msg.get()), size);

--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -105,13 +105,13 @@ class TOOLBOX_API Logger {
     Logger(Logger&&) noexcept = default;
     Logger& operator=(Logger&&) noexcept = default;
 
-    void write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg, std::size_t size) noexcept
+    void write_log(WallTime ts, LogLevel level, int tid, LogMsgPtr&& msg, std::size_t size) noexcept
     {
-        do_write_log(ts, level, std::move(msg), size);
+        do_write_log(ts, level, tid, std::move(msg), size);
     }
 
   protected:
-    virtual void do_write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg,
+    virtual void do_write_log(WallTime ts, LogLevel level, int tid, LogMsgPtr&& msg,
                               std::size_t size) noexcept = 0;
 };
 
@@ -119,6 +119,7 @@ class TOOLBOX_API AsyncLogger : public Logger {
     struct Task {
         WallTime ts;
         LogLevel level;
+        int tid;
         LogMsgPtr msg;
         std::size_t size;
     };
@@ -143,7 +144,7 @@ class TOOLBOX_API AsyncLogger : public Logger {
     void stop();
 
   private:
-    void do_write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg,
+    void do_write_log(WallTime ts, LogLevel level, int tid, LogMsgPtr&& msg,
                       std::size_t size) noexcept override;
 
     Logger& logger_;

--- a/toolbox/sys/Thread.hpp
+++ b/toolbox/sys/Thread.hpp
@@ -19,8 +19,8 @@
 
 #include <toolbox/Config.h>
 
-#include <string>
 #include <sched.h>
+#include <string>
 
 namespace toolbox {
 inline namespace sys {

--- a/toolbox/util/IntTypes.hpp
+++ b/toolbox/util/IntTypes.hpp
@@ -273,12 +273,9 @@ struct TypeTraits<ValueT> {
     }
 };
 
-struct Id16Policy : Int16Policy {
-};
-struct Id32Policy : Int32Policy {
-};
-struct Id64Policy : Int64Policy {
-};
+struct Id16Policy : Int16Policy {};
+struct Id32Policy : Int32Policy {};
+struct Id64Policy : Int64Policy {};
 
 /// 16 bit identifier.
 using Id16 = IntWrapper<Id16Policy>;

--- a/toolbox/util/IntTypes.ut.cpp
+++ b/toolbox/util/IntTypes.ut.cpp
@@ -26,8 +26,7 @@ using namespace toolbox;
 
 namespace {
 
-struct TestTag : Int32Policy {
-};
+struct TestTag : Int32Policy {};
 using Test = IntWrapper<TestTag>;
 
 constexpr Test operator""_test(unsigned long long val) noexcept

--- a/toolbox/util/Options.hpp
+++ b/toolbox/util/Options.hpp
@@ -36,11 +36,9 @@ inline namespace util {
 
 class Options;
 
-class NoOp {
-};
+class NoOp {};
 
-class Help {
-};
+class Help {};
 
 template <typename DerivedT>
 class Presence {

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -70,6 +70,15 @@ class StreamBuf final : public std::streambuf {
     }
     /// Update the internal storage.
     void set_storage(StoragePtr<MaxN> storage) noexcept { swap_storage(storage); }
+    /// Reset the current position back to the beginning of the buffer.
+    void reset() noexcept
+    {
+        if (storage_) {
+            setp(storage_->begin(), storage_->end());
+        }
+    }
+
+  private:
     /// Swap the internal storage.
     void swap_storage(StoragePtr<MaxN>& storage) noexcept
     {
@@ -81,15 +90,6 @@ class StreamBuf final : public std::streambuf {
             setp(nullptr, nullptr);
         }
     }
-    /// Reset the current position back to the beginning of the buffer.
-    void reset() noexcept
-    {
-        if (storage_) {
-            setp(storage_->begin(), storage_->end());
-        }
-    }
-
-  private:
     StoragePtr<MaxN> storage_;
 };
 
@@ -126,14 +126,13 @@ class OStream final : public std::ostream {
 
     /// Release the managed storage.
     StoragePtr<MaxN> release_storage() noexcept { return buf_.release_storage(); }
-    /// Update the internal storage.
+    /// Update the internal storage and clear i/o state.
     void set_storage(StoragePtr<MaxN> storage) noexcept
     {
-        return buf_.set_storage(std::move(storage));
+        buf_.set_storage(std::move(storage));
+        clear();
     }
-    /// Swap the internal storage.
-    void swap_storage(StoragePtr<MaxN>& storage) noexcept { buf_.swap_storage(storage); }
-    /// Reset the current position back to the beginning of the buffer.
+    /// Reset the current position back to the beginning of the buffer and clear i/o state.
     void reset() noexcept
     {
         buf_.reset();

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -25,8 +25,7 @@ namespace toolbox {
 inline namespace util {
 namespace detail {
 
-struct ResetState {
-};
+struct ResetState {};
 TOOLBOX_API std::ostream& operator<<(std::ostream& os, ResetState) noexcept;
 
 } // namespace detail

--- a/toolbox/util/Struct.ut.cpp
+++ b/toolbox/util/Struct.ut.cpp
@@ -23,10 +23,8 @@ using namespace toolbox;
 
 namespace {
 namespace tag {
-struct Foo {
-};
-struct Bar {
-};
+struct Foo {};
+struct Bar {};
 } // namespace tag
 
 static_assert(empty(Struct));


### PR DESCRIPTION
The thread-id must be acquired on the caller's thread rather than on the logger's worker thread.

SDB-3845