### PR TITLE
feat: alert on socket-level connection timeout

### DIFF
--- a/toolbox/net/StreamConnector.hpp
+++ b/toolbox/net/StreamConnector.hpp
@@ -85,6 +85,8 @@ class StreamConnector {
                 throw std::system_error{ec, "connect"};
             }
             static_cast<DerivedT*>(this)->on_sock_connect(now, std::move(sock), ep_);
+        } catch (const std::system_error& e) {
+            static_cast<DerivedT*>(this)->on_sock_connect_error(now, e);
         } catch (const std::exception& e) {
             static_cast<DerivedT*>(this)->on_sock_connect_error(now, e);
         }


### PR DESCRIPTION
A socket connection timeout almost always indicates a serious network issue.

SDB-5213