### PR TITLE
feat: extend Reactor metrics to include elapsed time

### DIFF
--- a/toolbox/io/Reactor.cpp
+++ b/toolbox/io/Reactor.cpp
@@ -79,15 +79,13 @@ int Reactor::poll(CyclTime now, Duration timeout)
         // Block indefinitely.
         n = epoll_.wait(buf, MaxEvents, ec);
     }
+    // Update cycle time after epoll() returns.
+    now = CyclTime::now();
     if (ec) {
         if (ec.value() != EINTR) {
             throw system_error{ec};
         }
         return 0;
-    }
-    // If the epoller call was a blocking call, then acquire the current time.
-    if (!is_zero(wait_until)) {
-        now = CyclTime::now();
     }
     int work{0};
     TOOLBOX_PROBE_SCOPED(reactor, dispatch, work);

--- a/toolbox/io/Reactor.hpp
+++ b/toolbox/io/Reactor.hpp
@@ -86,7 +86,7 @@ class TOOLBOX_API Reactor : public Waker {
             std::swap(sid_, rhs.sid_);
         }
 
-        /// Modify IO event subscription.
+        /// Modify I/O event subscription.
         void set_events(unsigned events, IoSlot slot, std::error_code& ec) noexcept
         {
             assert(reactor_);
@@ -140,6 +140,9 @@ class TOOLBOX_API Reactor : public Waker {
     // clang-format on
 
     void add_hook(Hook& hook) noexcept { hooks_.push_back(hook); }
+    /// Poll for I/O and timer events.
+    /// The thread-local cycle time is unconditionally updated after the call to epoll() returns.
+    /// Returns the number of events signalled.
     int poll(CyclTime now, Duration timeout = NoTimeout);
 
   protected:

--- a/toolbox/io/Runner.hpp
+++ b/toolbox/io/Runner.hpp
@@ -31,7 +31,8 @@ class Reactor;
 using HistogramPtr = std::unique_ptr<Histogram>;
 
 /// MetricCallbackFunction implementer is responsible for deleting the Histogram.
-using MetricCallbackFunction = std::function<void(CyclTime, HistogramPtr&&)>;
+using MetricCallbackFunction
+    = std::function<void(CyclTime now, HistogramPtr&& time_hist, HistogramPtr&& work_hist)>;
 
 class TOOLBOX_API ReactorRunner {
   public:


### PR DESCRIPTION
Extend Reactor metrics to include second histogram that records reactor event processing time.

SDB-5959