### PR TITLE
chore(net): switch uri parameter to string_view

### DIFF
--- a/toolbox/net/Endpoint.cpp
+++ b/toolbox/net/Endpoint.cpp
@@ -16,6 +16,8 @@
 
 #include "Endpoint.hpp"
 
+#include <toolbox/util/String.hpp>
+
 using namespace std;
 
 namespace toolbox {
@@ -40,7 +42,7 @@ pair<string, string> split_ip_addr(const string& addr, char delim)
     return {node, service};
 }
 
-pair<string, string> split_uri(const string& uri)
+pair<string, string> split_uri(string_view uri)
 {
     const auto pos = uri.find("://");
     string scheme, addr;
@@ -54,7 +56,7 @@ pair<string, string> split_uri(const string& uri)
 }
 } // namespace
 
-AddrInfoPtr parse_endpoint(const string& uri, int type)
+AddrInfoPtr parse_endpoint(string_view uri, int type)
 {
     int family{-1}, protocol{0};
     const auto [scheme, addr] = split_uri(uri);
@@ -88,7 +90,7 @@ AddrInfoPtr parse_endpoint(const string& uri, int type)
         return get_unix_addrinfo(addr, type);
     }
     if (family < 0) {
-        throw invalid_argument{"invalid uri: "s + uri};
+        throw invalid_argument{make_string("invalid uri: ", uri)};
     }
     auto [node, service] = split_ip_addr(addr, ':');
     return os::getaddrinfo(!node.empty() ? node.c_str() : nullptr,

--- a/toolbox/net/Endpoint.hpp
+++ b/toolbox/net/Endpoint.hpp
@@ -46,15 +46,15 @@ using UnixEndpoint = boost::asio::local::basic_endpoint<ProtocolT>;
 using UnixDgramEndpoint = UnixEndpoint<UnixDgramProtocol>;
 using UnixStreamEndpoint = UnixEndpoint<UnixStreamProtocol>;
 
-TOOLBOX_API AddrInfoPtr parse_endpoint(const std::string& uri, int type);
+TOOLBOX_API AddrInfoPtr parse_endpoint(std::string_view uri, int type);
 
-inline DgramEndpoint parse_dgram_endpoint(const std::string& uri)
+inline DgramEndpoint parse_dgram_endpoint(std::string_view uri)
 {
     const auto ai = parse_endpoint(uri, SOCK_DGRAM);
     return {ai->ai_addr, ai->ai_addrlen, ai->ai_protocol};
 }
 
-inline StreamEndpoint parse_stream_endpoint(const std::string& uri)
+inline StreamEndpoint parse_stream_endpoint(std::string_view uri)
 {
     const auto ai = parse_endpoint(uri, SOCK_STREAM);
     return {ai->ai_addr, ai->ai_addrlen, ai->ai_protocol};

--- a/toolbox/net/Resolver.cpp
+++ b/toolbox/net/Resolver.cpp
@@ -37,7 +37,7 @@ void Resolver::clear()
     return tq_.clear();
 }
 
-AddrInfoFuture Resolver::resolve(const std::string& uri, int type)
+AddrInfoFuture Resolver::resolve(std::string_view uri, int type)
 {
     Task task{[=]() -> AddrInfoPtr { return parse_endpoint(uri, type); }};
     auto future = task.get_future();

--- a/toolbox/net/Resolver.hpp
+++ b/toolbox/net/Resolver.hpp
@@ -59,7 +59,7 @@ class TOOLBOX_API Resolver {
     void clear();
 
     /// Schedule a URI socket name resolution.
-    AddrInfoFuture resolve(const std::string& uri, int type);
+    AddrInfoFuture resolve(std::string_view uri, int type);
 
   private:
     TaskQueue<Task> tq_;


### PR DESCRIPTION
Makes it easier to pass string_views to the function.