### PR TITLE
feat(lpfixgw): ITCH feed logging improvements to prevent throwing away data if overwhelmed

### DIFF
--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -128,6 +128,7 @@ class TOOLBOX_API AsyncLogger : public Logger {
 
   public:
     explicit AsyncLogger(Logger& logger);
+    AsyncLogger(Logger& logger, std::size_t tq_size);
     ~AsyncLogger() override;
 
     // Copy.
@@ -146,13 +147,15 @@ class TOOLBOX_API AsyncLogger : public Logger {
     void stop();
 
   private:
-    void write_all_messages();
+    /// Returns whether tq_ was full
+    bool write_all_messages();
     void do_write_log(WallTime ts, LogLevel level, int tid, LogMsgPtr&& msg,
                       std::size_t size) noexcept override;
 
     Logger& logger_;
     boost::lockfree::queue<Task, boost::lockfree::fixed_sized<true>> tq_{128};
     std::atomic<bool> stop_{false};
+    const std::size_t tq_size_{};
 };
 
 /// ScopedLogLevel provides a convenient RAII-style utility for setting the log-level for the


### PR DESCRIPTION
Retain the lockfree approach, however work on the basis that if the AsyncLogger queue is 80% full then consider it to be filling up quickly due to a microburst and don't sleep until (perhaps) the next cycle.

SDB-6112