### PR TITLE
perf(fix): Use boost vector as underlying storage for the buffer instead of the std::vector

### DIFF
--- a/toolbox/io/Buffer.hpp
+++ b/toolbox/io/Buffer.hpp
@@ -20,6 +20,7 @@
 #include <toolbox/Config.h>
 
 #include <boost/asio/buffer.hpp>
+#include <boost/container/vector.hpp>
 
 namespace toolbox {
 inline namespace io {
@@ -108,7 +109,7 @@ class TOOLBOX_API Buffer {
     std::size_t available() const noexcept { return buf_.size() - wpos_; }
 
     std::size_t rpos_{}, wpos_{};
-    std::vector<char> buf_;
+    boost::container::vector<char> buf_;
 };
 
 TOOLBOX_API ConstBuffer advance(ConstBuffer buf, std::size_t n) noexcept;


### PR DESCRIPTION
Buffer::prepare() is called every time when sth is about to be written to the buffer, it includes calling of vector::resize().

It turned out that resize() is not so cheap if current capacity is more than requested size, because it touches newly requested chunk of memory.
Measurements showed that boost::vector does it a bit more efficient by using memset() while std::vector uses std::__uninitialized_default_n_a()

SDB-6760