### PR TITLE
perf(fix): Do not call boost::vector::clear()

### DIFF
--- a/toolbox/io/Buffer.hpp
+++ b/toolbox/io/Buffer.hpp
@@ -78,7 +78,6 @@ class TOOLBOX_API Buffer {
     void clear() noexcept
     {
         rpos_ = wpos_ = 0;
-        buf_.clear();
     }
 
     /// Move characters from the write sequence to the read sequence.


### PR DESCRIPTION
io::Buffer has wptr and rptr which effectively controls buffer boundaries

SDB-6760