### PR TITLE
feat: Made sure prepare only returns what is requested.

### DIFF
--- a/toolbox/io/Buffer.hpp
+++ b/toolbox/io/Buffer.hpp
@@ -89,14 +89,12 @@ class TOOLBOX_API Buffer {
     /// Returns write buffer of at least size bytes.
     MutableBuffer prepare(std::size_t size)
     {
-        auto avail = available();
-        if (size > avail) {
+        if (const auto avail = available(); size > avail) {
             // More buffer space required.
             const auto diff = size - avail;
             buf_.resize(buf_.size() + diff);
-            avail = size;
         }
-        return {wptr(), avail};
+        return {wptr(), size};
     }
 
     /// Reserve storage.


### PR DESCRIPTION
Made sure prepare only returns what is requested. This counters the issue where comsume() can reclaim ~50% buffer space in advance making available a lot more than expected.

SDB-6933