### PR TITLE
feat: Increase AsyncLogger queue size

### DIFF
--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -151,7 +151,7 @@ class TOOLBOX_API AsyncLogger : public Logger {
                       std::size_t size) noexcept override;
 
     Logger& logger_;
-    boost::lockfree::queue<Task, boost::lockfree::fixed_sized<true>> tq_{128};
+    boost::lockfree::queue<Task, boost::lockfree::fixed_sized<true>> tq_{512};
     std::atomic<bool> stop_{false};
 };
 


### PR DESCRIPTION
Increase AsyncLogger queue size to reduce the likelihood of drops.

SDB-6988