### PR TITLE
feat(io): Add support for inotify API

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The Reactive C++ Toolbox.
 # Copyright (C) 2013-2019 Swirly Cloud Limited
-# Copyright (C) 2021 Reactive Markets Limited
+# Copyright (C) 2024 Reactive Markets Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 set(targets
   tb-echo-clnt
   tb-echo-serv
-  tb-http-serv)
+  tb-http-serv
+  tb-inotify)
 
 add_custom_target(tb-example DEPENDS ${targets})
 
@@ -29,3 +30,6 @@ target_link_libraries(tb-echo-serv ${tb_core_LIBRARY})
 
 add_executable(tb-http-serv HttpServ.cpp)
 target_link_libraries(tb-http-serv ${tb_core_LIBRARY})
+
+add_executable(tb-inotify Inotify.cpp)
+target_link_libraries(tb-inotify ${tb_core_LIBRARY})

--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -19,6 +19,8 @@
 #include <toolbox/sys.hpp>
 #include <toolbox/util.hpp>
 
+#include <map>
+
 using namespace std;
 using namespace toolbox;
 
@@ -37,7 +39,7 @@ void on_bar(const Request& /*req*/, http::OStream& os)
 class ExampleApp final : public App {
   public:
     using Slot = BasicSlot<const Request&, http::OStream&>;
-    using SlotMap = RobinMap<std::string, Slot>;
+    using SlotMap = std::map<std::string, Slot>;
 
     ~ExampleApp() override = default;
     void bind(const std::string& path, Slot slot) { slot_map_[path] = slot; }

--- a/example/Inotify.cpp
+++ b/example/Inotify.cpp
@@ -1,0 +1,175 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2024 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <toolbox/io.hpp>
+#include <toolbox/net.hpp>
+#include <toolbox/sys.hpp>
+#include <toolbox/util.hpp>
+
+using namespace toolbox;
+
+namespace {
+
+using Path = FileWatcher::Path;
+
+/// Example configuration.
+struct Config {
+    Path path;
+};
+
+using ConfigPtr = std::unique_ptr<Config>;
+using ConfigFuture = std::future<ConfigPtr>;
+
+class ConfigLoader {
+    using Task = std::packaged_task<ConfigPtr()>;
+
+  public:
+    explicit ConfigLoader(const Path& dir_name)
+    : dir_name_{dir_name}
+    {
+    }
+    ~ConfigLoader() = default;
+
+    // Copy.
+    ConfigLoader(const ConfigLoader& rhs) = delete;
+    ConfigLoader& operator=(const ConfigLoader& rhs) = delete;
+
+    // Move.
+    ConfigLoader(ConfigLoader&&) = delete;
+    ConfigLoader& operator=(ConfigLoader&&) = delete;
+
+    const Path& dir_name() const noexcept { return dir_name_; }
+    bool run()
+    {
+        return tq_.run([](Task&& t) { t(); });
+    }
+    void stop() { tq_.stop(); }
+    void clear()
+    {
+        // This will unblock waiters by throwing a "broken promise" exception.
+        return tq_.clear();
+    }
+    ConfigFuture load(const Path& file_name)
+    {
+        Task task{[this, file_name = std::move(file_name)]() -> ConfigPtr {
+            // TODO: load config from filesystem.
+            return ConfigPtr{new Config{.path = dir_name_ / file_name}};
+        }};
+        auto future{task.get_future()};
+        tq_.push(std::move(task));
+        return future;
+    }
+
+  private:
+    const Path dir_name_;
+    TaskQueue<Task> tq_;
+};
+
+class App {
+  public:
+    App(CyclTime now, Reactor& reactor, Inotify& inotify, ConfigLoader& config_loader)
+    : config_loader_{config_loader}
+    , file_watcher_{reactor, inotify, config_loader.dir_name()}
+    // Immediate and then at 5s intervals.
+    , tmr_{reactor.timer(now.mono_time(), 5s, Priority::Low, bind<&App::on_timer>(this))}
+    {
+        // Bind on_config_update slot to the foo.conf configuration file.
+        file_watcher_.bind("foo.conf", bind<&App::on_config_update>(this));
+        // Trigger initial config load.
+        config_future_ = config_loader_.load("foo.conf");
+    }
+    ~App() = default;
+
+  private:
+    void on_config_update(const Path& file_name, std::uint32_t event_mask)
+    {
+        if ((event_mask & IN_CLOSE_WRITE) == IN_CLOSE_WRITE) {
+            TOOLBOX_INFO << "config " << file_name << " updated (IN_CLOSE_WRITE)";
+        }
+        if ((event_mask & IN_MOVED_TO) == IN_MOVED_TO) {
+            TOOLBOX_INFO << "config " << file_name << " updated (IN_MOVED_TO)";
+        }
+        config_future_ = config_loader_.load(file_name);
+    }
+    void on_timer(CyclTime /*now*/, Timer& /*tmr*/)
+    {
+        if (config_future_.valid()) {
+            if (!is_ready(config_future_)) {
+                TOOLBOX_INFO << "config pending";
+                return;
+            }
+            try {
+                config_ = config_future_.get();
+            } catch (const std::exception& e) {
+                TOOLBOX_ERROR << "could not load config: " << e.what();
+                config_future_ = config_loader_.load("foo.conf");
+                return;
+            }
+            TOOLBOX_INFO << "config loaded: " << config_->path;
+        }
+    }
+
+    ConfigLoader& config_loader_;
+    FileWatcher file_watcher_;
+    Timer tmr_;
+    ConfigFuture config_future_;
+    ConfigPtr config_;
+};
+} // namespace
+
+int main()
+{
+    using namespace std::literals::string_literals;
+    int ret = 1;
+    try {
+
+        const auto start_time{CyclTime::now()};
+        Reactor reactor{1024};
+        Inotify inotify{IN_NONBLOCK};
+        ConfigLoader config_loader{"/tmp/config"};
+        App app{start_time, reactor, inotify, config_loader};
+
+        // Start service threads.
+        pthread_setname_np(pthread_self(), "main");
+        ReactorRunner reactor_runner{reactor, 100, "reactor"s};
+        Runner config_loader_runner{config_loader, "config_loader"s};
+
+        // Wait for termination.
+        SigWait sig_wait;
+        for (;;) {
+            switch (const auto sig = sig_wait()) {
+            case SIGHUP:
+                TOOLBOX_INFO << "received SIGHUP";
+                continue;
+            case SIGINT:
+                TOOLBOX_INFO << "received SIGINT";
+                break;
+            case SIGTERM:
+                TOOLBOX_INFO << "received SIGTERM";
+                break;
+            default:
+                TOOLBOX_INFO << "received signal: " << sig;
+                continue;
+            }
+            break;
+        }
+        ret = 0;
+
+    } catch (const std::exception& e) {
+        TOOLBOX_ERROR << "exception on main thread: " << e.what();
+    }
+    return ret;
+}

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -59,6 +59,7 @@ set(lib_SOURCES
   io/File.cpp
   io/Handle.cpp
   io/Hook.cpp
+  io/Inotify.cpp
   io/Reactor.cpp
   io/Runner.cpp
   io/Stream.cpp

--- a/toolbox/io.hpp
+++ b/toolbox/io.hpp
@@ -25,6 +25,7 @@
 #include "io/File.hpp"
 #include "io/Handle.hpp"
 #include "io/Hook.hpp"
+#include "io/Inotify.hpp"
 #include "io/Reactor.hpp"
 #include "io/Runner.hpp"
 #include "io/Stream.hpp"

--- a/toolbox/io/Buffer.hpp
+++ b/toolbox/io/Buffer.hpp
@@ -75,10 +75,7 @@ class TOOLBOX_API Buffer {
     std::size_t size() const noexcept { return wpos_ - rpos_; }
 
     /// Clear buffer.
-    void clear() noexcept
-    {
-        rpos_ = wpos_ = 0;
-    }
+    void clear() noexcept { rpos_ = wpos_ = 0; }
 
     /// Move characters from the write sequence to the read sequence.
     void commit(std::size_t count) noexcept { wpos_ += count; }

--- a/toolbox/io/Handle.hpp
+++ b/toolbox/io/Handle.hpp
@@ -102,7 +102,7 @@ constexpr bool operator!=(const BasicHandle<PolicyT>& lhs, const BasicHandle<Pol
 struct FilePolicy {
     using Id = int;
     static constexpr int invalid() noexcept { return -1; }
-    static void close(int d) noexcept { ::close(d); }
+    static void close(int fd) noexcept { ::close(fd); }
 };
 
 using FileHandle = BasicHandle<FilePolicy>;

--- a/toolbox/io/Inotify.cpp
+++ b/toolbox/io/Inotify.cpp
@@ -1,0 +1,54 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2024 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Inotify.hpp"
+
+namespace toolbox {
+inline namespace io {
+
+FileWatcher::FileWatcher(Reactor& r, Inotify& inotify, const Path& dir_name, std::uint32_t mask)
+: watch_dir_{inotify.add_watch(dir_name.c_str(), mask)}
+, sub_{r.subscribe(inotify.fd(), EpollIn, toolbox::bind<&FileWatcher::on_inotify>(this))}
+{
+}
+
+void FileWatcher::on_inotify(CyclTime /*now*/, int fd, unsigned events)
+{
+    if (events & (EpollIn | EpollHup)) {
+        char buf[1024 * (sizeof(struct inotify_event) + NAME_MAX + 1)];
+        const auto size{os::read(fd, buf, sizeof(buf))};
+        if (size == 0) {
+            // FIXME: a zero return normally indicates end of file.
+            //  Can this happen on an inotify descriptor?
+            //  And if so, how should the application behave?
+            watch_dir_.reset();
+            sub_.reset();
+            return;
+        }
+        for (std::size_t i{0}; i < size;) {
+            inotify_event* event{reinterpret_cast<inotify_event*>(&buf[i])};
+            const Path file_name{event->name};
+            const auto it{slot_map_.find(file_name)};
+            if (it != slot_map_.end()) {
+                it->second(file_name, event->mask);
+            }
+            i += sizeof(struct inotify_event) + event->len;
+        }
+    }
+}
+
+} // namespace io
+} // namespace toolbox

--- a/toolbox/io/Inotify.hpp
+++ b/toolbox/io/Inotify.hpp
@@ -1,0 +1,173 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2024 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOOLBOX_IO_INOTIFY_HPP
+#define TOOLBOX_IO_INOTIFY_HPP
+
+#include <toolbox/io/Reactor.hpp>
+
+#include <sys/inotify.h>
+
+#include <filesystem>
+#include <map>
+
+namespace toolbox {
+inline namespace io {
+
+struct WatchFile {
+    int fd{-1}, wd{-1};
+};
+
+constexpr bool operator==(WatchFile lhs, WatchFile rhs)
+{
+    return lhs.fd == rhs.fd && lhs.wd == rhs.wd;
+}
+
+constexpr bool operator!=(WatchFile lhs, WatchFile rhs)
+{
+    return !(lhs == rhs);
+}
+
+struct WatchFilePolicy {
+    using Id = WatchFile;
+    static constexpr WatchFile invalid() noexcept { return WatchFile{}; }
+    static void close(WatchFile wf) noexcept
+    {
+        ::inotify_rm_watch(wf.fd, wf.wd);
+        ::close(wf.wd);
+    }
+};
+
+using WatchFileHandle = BasicHandle<WatchFilePolicy>;
+
+/// Initialise an inotify instance.
+inline FileHandle inotify_init(int flags, std::error_code& ec) noexcept
+{
+    const auto fd = ::inotify_init1(flags);
+    if (fd < 0) {
+        ec = make_error(errno);
+    }
+    return fd;
+}
+
+/// Initialise an inotify instance.
+inline FileHandle inotify_init(std::error_code& ec) noexcept
+{
+    return inotify_init(0, ec);
+}
+
+/// Initialise an inotify instance and returns a file descriptor associated with a new inotify
+/// event queue.
+inline FileHandle inotify_init(int flags = 0)
+{
+    const auto fd = ::inotify_init1(flags);
+    if (fd < 0) {
+        throw std::system_error{make_error(errno), "inotify_init1"};
+    }
+    return fd;
+}
+
+/// Add a watch to an initialised inotify instance.
+inline WatchFileHandle inotify_add_watch(int fd, const char* path, std::uint32_t mask,
+                                         std::error_code& ec) noexcept
+{
+    const auto wd = ::inotify_add_watch(fd, path, mask);
+    if (wd < 0) {
+        ec = make_error(errno);
+        return {};
+    }
+    return WatchFile{.fd = fd, .wd = wd};
+}
+
+/// Add a watch to an initialised inotify instance.
+inline WatchFileHandle inotify_add_watch(int fd, const char* path, std::uint32_t mask)
+{
+    const auto wd = ::inotify_add_watch(fd, path, mask);
+    if (wd < 0) {
+        throw std::system_error{make_error(errno), "inotify_add_watch"};
+    }
+    return WatchFile{.fd = fd, .wd = wd};
+}
+
+/// Inotify provides a simplified interface to an inotify instance.
+class TOOLBOX_API Inotify {
+  public:
+    explicit Inotify(int flags = 0)
+    : fh_{inotify_init(flags)}
+    {
+    }
+    ~Inotify() = default;
+
+    // Copy.
+    Inotify(const Inotify&) = delete;
+    Inotify& operator=(const Inotify&) = delete;
+
+    // Move.
+    Inotify(Inotify&&) noexcept = default;
+    Inotify& operator=(Inotify&&) noexcept = default;
+
+    int fd() const noexcept { return fh_.get(); }
+
+    /// Add a watch to an initialised inotify instance.
+    [[nodiscard]] WatchFileHandle add_watch(const char* path, std::uint32_t mask,
+                                            std::error_code& ec) noexcept
+    {
+        return inotify_add_watch(fh_.get(), path, mask, ec);
+    }
+    /// Add a watch to an initialised inotify instance.
+    [[nodiscard]] WatchFileHandle add_watch(const char* path, std::uint32_t mask)
+    {
+        return inotify_add_watch(fh_.get(), path, mask);
+    }
+
+  private:
+    FileHandle fh_;
+};
+
+/// FileWatcher watches for changes to files in a directory.
+class TOOLBOX_API FileWatcher {
+  public:
+    using Path = std::filesystem::path;
+    using Slot = BasicSlot<const Path&, std::uint32_t>;
+    using SlotMap = std::map<Path, Slot>;
+
+    FileWatcher(Reactor& r, Inotify& inotify, const Path& dir_name,
+                std::uint32_t mask = IN_CLOSE_WRITE | IN_MOVED_TO);
+    ~FileWatcher() = default;
+
+    // Copy.
+    FileWatcher(const FileWatcher&) = delete;
+    FileWatcher& operator=(const FileWatcher&) = delete;
+
+    // Move.
+    FileWatcher(FileWatcher&&) noexcept = default;
+    FileWatcher& operator=(FileWatcher&&) noexcept = default;
+
+    /// Bind slot to a file within the directory.
+    void bind(const Path& file_name, Slot slot) { slot_map_[file_name] = slot; }
+
+  private:
+    void on_inotify(CyclTime /*now*/, int fd, unsigned events);
+
+    WatchFileHandle watch_dir_;
+    Reactor::Handle sub_;
+    SlotMap slot_map_;
+};
+
+} // namespace io
+} // namespace toolbox
+
+#endif // TOOLBOX_IO_INOTIFY_HPP

--- a/toolbox/io/Runner.cpp
+++ b/toolbox/io/Runner.cpp
@@ -122,8 +122,8 @@ ReactorRunner::ReactorRunner(Reactor& r, long busy_cycles, ThreadConfig config,
 ReactorRunner::ReactorRunner(Reactor& r, long busy_cycles, ThreadConfig config,
                              MetricCallbackFunction metric_cb, LoopCallbackFunction loop_cb)
 : reactor_{r}
-, thread_{run_metrics_reactor, std::ref(r), busy_cycles, config, std::cref(stop_),
-          metric_cb, loop_cb}
+, thread_{run_metrics_reactor, std::ref(r), busy_cycles, config,
+          std::cref(stop_),    metric_cb,   loop_cb}
 {
 }
 

--- a/toolbox/io/Runner.hpp
+++ b/toolbox/io/Runner.hpp
@@ -34,8 +34,7 @@ using HistogramPtr = std::unique_ptr<Histogram>;
 using MetricCallbackFunction
     = std::function<void(CyclTime now, HistogramPtr&& time_hist, HistogramPtr&& work_hist)>;
 /// LoopCallbackFunction called at end of each Reactor loop, indicating micros taken and work done.
-using LoopCallbackFunction
-    = std::function<void(CyclTime now)>;
+using LoopCallbackFunction = std::function<void(CyclTime now)>;
 
 class TOOLBOX_API ReactorRunner {
   public:

--- a/toolbox/net/Resolver.cpp
+++ b/toolbox/net/Resolver.cpp
@@ -37,9 +37,9 @@ void Resolver::clear()
     return tq_.clear();
 }
 
-AddrInfoFuture Resolver::resolve(std::string_view uri, int type)
+AddrInfoFuture Resolver::resolve(std::string uri, int type)
 {
-    Task task{[=]() -> AddrInfoPtr { return parse_endpoint(uri, type); }};
+    Task task{[uri = std::move(uri), type]() -> AddrInfoPtr { return parse_endpoint(uri, type); }};
     auto future = task.get_future();
     tq_.push(std::move(task));
     return future;

--- a/toolbox/net/Resolver.hpp
+++ b/toolbox/net/Resolver.hpp
@@ -32,7 +32,6 @@ using AddrInfoFuture = std::future<AddrInfoPtr>;
 /// The Resolver is designed to resolve socket URIs to address endpoints on a background thread,
 /// which may include a DNS lookup depending on the URI.
 class TOOLBOX_API Resolver {
-    using Lock = std::unique_lock<std::mutex>;
     using Task = std::packaged_task<AddrInfoPtr()>;
 
   public:
@@ -59,7 +58,7 @@ class TOOLBOX_API Resolver {
     void clear();
 
     /// Schedule a URI socket name resolution.
-    AddrInfoFuture resolve(std::string_view uri, int type);
+    AddrInfoFuture resolve(std::string uri, int type);
 
   private:
     TaskQueue<Task> tq_;


### PR DESCRIPTION
The inotify API provides a mechanism for monitoring filesystem events. Inotify can be used to monitor individual files, or to monitor directories. When a directory is monitored, inotify will return events for the directory itself, and for files inside the directory.

SDB-6742