### PR TITLE
feat(io): Add support for dynamic k8s config loading

### DIFF
--- a/toolbox/io/Inotify.cpp
+++ b/toolbox/io/Inotify.cpp
@@ -19,10 +19,26 @@
 namespace toolbox {
 inline namespace io {
 
-FileWatcher::FileWatcher(Reactor& r, Inotify& inotify, const Path& dir_name, std::uint32_t mask)
-: watch_dir_{inotify.add_watch(dir_name.c_str(), mask)}
+FileWatcher::FileWatcher(Reactor& r, Inotify& inotify)
+: inotify_{&inotify}
 , sub_{r.subscribe(inotify.fd(), EpollIn, toolbox::bind<&FileWatcher::on_inotify>(this))}
 {
+}
+
+void FileWatcher::watch(const Path& path, Slot slot, std::uint32_t mask)
+{
+    auto new_wh{inotify_->add_watch(path.c_str(), mask)};
+    auto& watch{path_index_[path]};
+    if (watch.wh == new_wh) {
+        // Update entries for existing watch descriptor.
+        watch.slot = slot;
+        return;
+    }
+    wd_index_[new_wh.get().wd] = &watch;
+    // Update watch.
+    // N.B. in the unlikely event that an exception is thrown, the dangling entry in wd_index_
+    // would be cleaned-up by the garbage collection logic in on_inotify function below.
+    watch = Watch{.path = path, .slot = slot, .wh = std::move(new_wh)};
 }
 
 void FileWatcher::on_inotify(CyclTime /*now*/, int fd, unsigned events)
@@ -34,18 +50,34 @@ void FileWatcher::on_inotify(CyclTime /*now*/, int fd, unsigned events)
             // FIXME: a zero return normally indicates end of file.
             //  Can this happen on an inotify descriptor?
             //  And if so, how should the application behave?
-            watch_dir_.reset();
+            wd_index_.clear();
+            path_index_.clear();
             sub_.reset();
             return;
         }
         for (std::size_t i{0}; i < size;) {
             inotify_event* event{reinterpret_cast<inotify_event*>(&buf[i])};
-            const Path file_name{event->name};
-            const auto it{slot_map_.find(file_name)};
-            if (it != slot_map_.end()) {
-                it->second(file_name, event->mask);
+            const auto it{wd_index_.find(event->wd)};
+            if (it != wd_index_.end()) {
+                it->second->slot(it->second->path, event->wd, event->mask);
             }
             i += sizeof(struct inotify_event) + event->len;
+        }
+        // Perform garbage collection on dangling entries in wd_index_. These entries refer to
+        // watch handles in path_index_ that are now associated with different watch descriptors.
+        // This situation typically arises when a watch is updated, causing the path to point to
+        // a new inode.
+        //
+        // Note: This garbage collection occurs after all inotify events have been dispatched.
+        // This ensures that events for old watch descriptors are still dispatched, even if the
+        // path was rebound during the iteration.
+        //
+        for (auto it{wd_index_.cbegin()}; it != wd_index_.cend();) {
+            if (it->first != it->second->wh.get().wd) {
+                it = wd_index_.erase(it);
+            } else {
+                ++it;
+            }
         }
     }
 }

--- a/toolbox/util/Tokeniser.hpp
+++ b/toolbox/util/Tokeniser.hpp
@@ -25,7 +25,7 @@ namespace toolbox {
 inline namespace util {
 using sv = std::string_view;
 
-class Tokeniser {    
+class Tokeniser {
   public:
     constexpr Tokeniser(std::string_view buf, std::string_view delims) noexcept
     {


### PR DESCRIPTION
On Kubernetes, inotify only receives the IN_DELETE_SELF event on config maps. This deletion event breaks the inotify watch and so code needs to handle re-establishing the watch every time the file is updated.

SDB-7208