### PR TITLE
feat(logger): Increase AsyncLogger queue size and decrease sleep time

### DIFF
--- a/toolbox/sys/Logger.cpp
+++ b/toolbox/sys/Logger.cpp
@@ -205,7 +205,7 @@ void AsyncLogger::write_all_messages()
 bool AsyncLogger::run()
 {
     write_all_messages();
-    std::this_thread::sleep_for(50ms);
+    std::this_thread::sleep_for(25ms);
 
     return (!tq_.empty() || !stop_);
 }

--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -151,7 +151,7 @@ class TOOLBOX_API AsyncLogger : public Logger {
                       std::size_t size) noexcept override;
 
     Logger& logger_;
-    boost::lockfree::queue<Task, boost::lockfree::fixed_sized<true>> tq_{512};
+    boost::lockfree::queue<Task, boost::lockfree::fixed_sized<true>> tq_{1024};
     std::atomic<bool> stop_{false};
 };
 


### PR DESCRIPTION
Increasing queue size and decreasing sleep time should help to avoid situation when logs are dropped due to full queue