### PR TITLE
fix: fix some issues caught by clang-analyzer

### DIFF
--- a/toolbox/io/Handle.ut.cpp
+++ b/toolbox/io/Handle.ut.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(HandleMoveCase)
     TestHandle h{1};
     TestHandle{std::move(h)};
     BOOST_CHECK_EQUAL(last_closed, 1);
-    // NOLINTNEXTLINE(bugprone-use-after-move)
+    // NOLINTNEXTLINE(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
     BOOST_CHECK_EQUAL(h.get(), -1);
 
     h.reset(2);
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(HandleMoveCase)
         tmp = std::move(h);
     }
     BOOST_CHECK_EQUAL(last_closed, 2);
-    // NOLINTNEXTLINE(bugprone-use-after-move)
+    // NOLINTNEXTLINE(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
     BOOST_CHECK_EQUAL(h.get(), -1);
 }
 

--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -50,7 +50,7 @@ inline AddrInfoPtr getaddrinfo(const char* node, const char* service, const addr
     const auto err = ::getaddrinfo(node, service, &hints, &ai);
     if (err != 0) {
         throw std::system_error{make_gai_error_code(err),
-                                "getaddrinfo (" + std::string{node} + ")"};
+                                "getaddrinfo (" + std::string{node ? node : ""} + ")"};
     }
     return {ai, freeaddrinfo};
 }

--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -64,6 +64,7 @@ BOOST_AUTO_TEST_SUITE(LogSuite)
 
 BOOST_AUTO_TEST_CASE(LogLabelCase)
 {
+    //NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     BOOST_CHECK_EQUAL(strcmp(log_label(LogLevel{-1}), "NONE"), 0);
     BOOST_CHECK_EQUAL(strcmp(log_label(LogLevel::None), "NONE"), 0);
     BOOST_CHECK_EQUAL(strcmp(log_label(LogLevel::Crit), "CRIT"), 0);
@@ -73,6 +74,7 @@ BOOST_AUTO_TEST_CASE(LogLabelCase)
     BOOST_CHECK_EQUAL(strcmp(log_label(LogLevel::Notice), "NOTICE"), 0);
     BOOST_CHECK_EQUAL(strcmp(log_label(LogLevel::Info), "INFO"), 0);
     BOOST_CHECK_EQUAL(strcmp(log_label(LogLevel::Debug), "DEBUG"), 0);
+    //NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     BOOST_CHECK_EQUAL(strcmp(log_label(LogLevel{99}), "DEBUG"), 0);
 }
 


### PR DESCRIPTION
Fixes a possible nullptr string construction which will throw, hiding
the original error message.
Silences some other warnings on purposeful issues.