### PR TITLE
chore(cmake): Allow disabling clang-tidy

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,7 +74,8 @@ jobs:
             -DTOOLBOX_BUILD_SHARED=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }}
+            -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
+            -DENABLE_CLANG_TIDY=OFF
 
       - name: Build project
         run: cd build && VERBOSE=1 make -j2 all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,9 +198,11 @@ install(FILES
   COMPONENT doc
 )
 
+option(ENABLE_CLANG_TIDY "Enable clang-tidy" ON)
+
 # Enable clang-tidy if program exists.
 find_program(CLANG_TIDY clang-tidy HINTS "${TOOLBOX_TOOLSET}/bin")
-if(CLANG_TIDY AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(CLANG_TIDY AND ENABLE_CLANG_TIDY AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   message(STATUS "Found clang-tidy")
   set(CMAKE_CXX_CLANG_TIDY
     "${CLANG_TIDY}"


### PR DESCRIPTION
Takes too long in CI builds, this will allow us to disable it for only those builds.