### PR TITLE
Improve dec_digits performance and benchmarking methodology

### DIFF
--- a/bench/Util.bm.cpp
+++ b/bench/Util.bm.cpp
@@ -71,6 +71,26 @@ std::vector<std::int64_t> generate_mixed_digit_nums(std::int64_t N, int K) noexc
 
 const std::vector random_digit_nums = generate_mixed_digit_nums(1'000'000, 7);
 
+int dec_digits_branch(std::int64_t i) noexcept __attribute__((noinline));
+int dec_digits_branch(std::int64_t i) noexcept
+{
+    return i < 10000000000        ? i < 100000 ? i < 100 ? i < 10 ? 1 : 2
+                       : i < 1000                        ? 3
+                       : i < 10000                       ? 4
+                                                         : 5
+                   : i < 10000000              ? i < 1000000 ? 6 : 7
+                   : i < 100000000             ? 8
+                   : i < 1000000000            ? 9
+                                               : 10
+        : i < 1000000000000000    ? i < 1000000000000 ? i < 100000000000 ? 11 : 12
+               : i < 10000000000000                   ? 13
+               : i < 100000000000000                  ? 14
+                                                      : 15
+        : i < 100000000000000000  ? i < 10000000000000000 ? 16 : 17
+        : i < 1000000000000000000 ? 18
+                                  : 19;
+}
+
 int dec_digits_div(int64_t i) noexcept __attribute__((noinline));
 int dec_digits_div(int64_t i) noexcept
 {
@@ -248,11 +268,32 @@ TOOLBOX_BENCHMARK(to_string_int)
     }
 }
 
-TOOLBOX_BENCHMARK(dec_digits_lib)
+TOOLBOX_BENCHMARK(dec_digits_lib_unsigned)
+{
+    while (ctx) {
+        for (auto i : ctx.range(random_digit_nums.size())) {
+            auto rnum = static_cast<uint64_t>(random_digit_nums[i]);
+            auto x = util::dec_digits(rnum);
+            bm::do_not_optimise(x);
+        }
+    }
+}
+
+TOOLBOX_BENCHMARK(dec_digits_lib_signed)
 {
     while (ctx) {
         for (auto i : ctx.range(random_digit_nums.size())) {
             auto x = util::dec_digits(random_digit_nums[i]);
+            bm::do_not_optimise(x);
+        }
+    }
+}
+
+TOOLBOX_BENCHMARK(dec_digits_branch)
+{
+    while (ctx) {
+        for (auto i : ctx.range(random_digit_nums.size())) {
+            auto x = ::dec_digits_branch(random_digit_nums[i]);
             bm::do_not_optimise(x);
         }
     }

--- a/toolbox/util/Math.hpp
+++ b/toolbox/util/Math.hpp
@@ -21,6 +21,9 @@
 
 #include <bit>
 #include <cmath>
+#include <array>
+#include <cassert>
+#include <cstdint>
 
 namespace toolbox {
 inline namespace util {
@@ -151,6 +154,37 @@ constexpr std::size_t ceil(std::size_t dividend, std::size_t divisor) noexcept
 {
     return (dividend - 1) / divisor + 1;
 }
+
+/// Returns the value of 10 raised to the power n (i.e. 10^n)
+///
+/// \param n exponent -- must be in the range [0, 19]
+constexpr std::uint64_t pow10(int n) noexcept {
+    constexpr std::array<std::uint64_t, 20> DecimalPowers = {
+        1ULL,
+        10ULL,
+        100ULL,
+        1000ULL,
+        10000ULL,
+        100000ULL,
+        1000000ULL,
+        10000000ULL,
+        100000000ULL,
+        1000000000ULL,
+        10000000000ULL,
+        100000000000ULL,
+        1000000000000ULL,
+        10000000000000ULL,
+        100000000000000ULL,
+        1000000000000000ULL,
+        10000000000000000ULL,
+        100000000000000000ULL,
+        1000000000000000000ULL,
+        10000000000000000000ULL
+    };
+
+    assert(n >= 0 && static_cast<std::size_t>(n) < DecimalPowers.size());
+    return DecimalPowers[n];
+};
 
 } // namespace util
 } // namespace toolbox

--- a/toolbox/util/Utility.ut.cpp
+++ b/toolbox/util/Utility.ut.cpp
@@ -16,6 +16,7 @@
 
 #include "Utility.hpp"
 #include <cmath>
+#include <limits>
 
 #include <boost/test/unit_test.hpp>
 
@@ -208,28 +209,186 @@ BOOST_AUTO_TEST_CASE(HexDigitsCase)
     BOOST_CHECK_EQUAL(hex_digits(0x1234567890abcdefU), 16);
 }
 
-BOOST_AUTO_TEST_CASE(DecDigitsCase)
+BOOST_AUTO_TEST_CASE(DecDigitsUnsignedCase)
 {
-    BOOST_CHECK_EQUAL(dec_digits(0), 1);
-    BOOST_CHECK_EQUAL(dec_digits(1), 1);
-    BOOST_CHECK_EQUAL(dec_digits(10), 2);
-    BOOST_CHECK_EQUAL(dec_digits(100), 3);
-    BOOST_CHECK_EQUAL(dec_digits(1000), 4);
-    BOOST_CHECK_EQUAL(dec_digits(10000), 5);
-    BOOST_CHECK_EQUAL(dec_digits(100000), 6);
-    BOOST_CHECK_EQUAL(dec_digits(1000000), 7);
-    BOOST_CHECK_EQUAL(dec_digits(10000000), 8);
-    BOOST_CHECK_EQUAL(dec_digits(100000000), 9);
-    BOOST_CHECK_EQUAL(dec_digits(1000000000), 10);
-    BOOST_CHECK_EQUAL(dec_digits(10000000000), 11);
-    BOOST_CHECK_EQUAL(dec_digits(100000000000), 12);
-    BOOST_CHECK_EQUAL(dec_digits(1000000000000), 13);
-    BOOST_CHECK_EQUAL(dec_digits(10000000000000), 14);
-    BOOST_CHECK_EQUAL(dec_digits(100000000000000), 15);
-    BOOST_CHECK_EQUAL(dec_digits(1000000000000000), 16);
-    BOOST_CHECK_EQUAL(dec_digits(10000000000000000), 17);
-    BOOST_CHECK_EQUAL(dec_digits(100000000000000000), 18);
-    BOOST_CHECK_EQUAL(dec_digits(1000000000000000000), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{0}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{9}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{11}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{99}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{101}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{999}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1001}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{9999}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10001}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{99999}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100001}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{999999}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000001}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{9999999}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000001}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{99999999}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000000}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000001}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{999999999}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000000}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000001}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{9999999999}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000000}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000001}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{99999999999}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000000000}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000000001}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{999999999999}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000000000}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000000001}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{9999999999999}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000000000}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000000001}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{99999999999999}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000000000000}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000000000001}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{999999999999999}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000000000000}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000000000001}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{9999999999999999}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000000000000}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000000000001}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{99999999999999999}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000000000000000}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{100000000000000001}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{999999999999999999}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000000000000000}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{1000000000000000001}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{9999999999999999999ULL}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000000000000000ULL}), 20);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{10000000000000000001ULL}), 20);
+    BOOST_CHECK_EQUAL(dec_digits(std::uint64_t{18446744073709551615ULL}), 20);
+}
+
+BOOST_AUTO_TEST_CASE(DecDigitSignedCase)
+{
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-9}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-11}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-99}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-101}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-999}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1001}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-9999}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10001}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-99999}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100001}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-999999}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000001}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-9999999}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000000}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000001}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-99999999}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000000}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000001}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-999999999}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000000}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000001}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-9999999999}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000000000}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000000001}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-99999999999}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000000000}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000000001}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-999999999999}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000000000}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000000001}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-9999999999999}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000000000000}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000000000001}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-99999999999999}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000000000000}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000000000001}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-999999999999999}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000000000000}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000000000001}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-9999999999999999}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000000000000000}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-10000000000000001}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-99999999999999999}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000000000000000}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-100000000000000001}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-999999999999999999}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000000000000000}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-1000000000000000001}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{-9223372036854775807}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::numeric_limits<std::int64_t>::min()), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{0}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{9}), 1);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{11}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{99}), 2);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{101}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{999}), 3);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1001}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{9999}), 4);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10001}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{99999}), 5);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100001}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{999999}), 6);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000001}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{9999999}), 7);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000000}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000001}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{99999999}), 8);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000000}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000001}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{999999999}), 9);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000000}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000001}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{9999999999}), 10);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000000000}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000000001}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{99999999999}), 11);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000000000}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000000001}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{999999999999}), 12);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000000000}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000000001}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{9999999999999}), 13);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000000000000}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000000000001}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{99999999999999}), 14);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000000000000}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000000000001}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{999999999999999}), 15);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000000000000}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000000000001}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{9999999999999999}), 16);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000000000000000}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{10000000000000001}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{99999999999999999}), 17);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000000000000000}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{100000000000000001}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{999999999999999999}), 18);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000000000000000}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{1000000000000000001}), 19);
+    BOOST_CHECK_EQUAL(dec_digits(std::int64_t{9223372036854775807}), 19);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Note to reviewers: This pull request consists of 2 commits, so view separately for easier reviewing.**

### The first commit changes how dec_digits is benchmarked (i.e. using randomly generated numbers).
In this commit, you may notice K=7 for the benchmarks. This means that 1 to 7 digit random numbers will be used for benchmarking i.e. [1, 10^7). The reasoning for that is because I think very large numbers (>7 digits) are much less common in production.

#### BEFORE commit (baseline results):
```
NAME                                                   COUNT       MIN       %50       %95       %99     %99.9    %99.99
------------------------------------------------------------------------------------------------------------------------
dec_digits_lib                                    3516840000         0         0         0         0         0         0
dec_digits_div                                    1205850000     0.002     0.002     0.002     0.003     0.004     0.005
dec_digits_math                                    152790000     0.018     0.019      0.02     0.021     0.027     0.034
dec_digits_stdio                                    90960000     0.028     0.032     0.033     0.034     0.046     0.062
dec_digits_less                                   3694740000         0         0         0         0         0         0
```
Note that the results indicate dec_digits_less is faster than than the dec_digits_lib by 1.05x (i.e. 5%)

#### AFTER commit (K=7):
```
NAME                                                   COUNT       MIN       %50       %95       %99     %99.9    %99.99
------------------------------------------------------------------------------------------------------------------------
dec_digits_lib                                     478000000     0.005     0.006     0.006     0.006     0.007     0.007
dec_digits_div                                     266000000     0.010     0.011     0.011     0.012     0.012     0.012
dec_digits_math                                    170000000     0.017     0.017     0.017     0.018     0.018     0.018
dec_digits_stdio                                    73000000     0.040     0.041     0.041     0.043     0.043     0.043
dec_digits_less                                    367000000     0.008     0.008     0.008     0.008     0.009     0.009
```
Now, the benchmark shows dec_digits_lib is faster than dec_digits_less by 1.3x when dealing with integers up to 10^7.

#### AFTER commit (K=19).
Adding K=19 benchmark results here if anyone is curious how dec_digits performs when dealing with integers of all digit sizes possible (for int64).
```
NAME                                                   COUNT       MIN       %50       %95       %99     %99.9    %99.99
------------------------------------------------------------------------------------------------------------------------
dec_digits_lib                                     291000000     0.010     0.010     0.010     0.010     0.010     0.010
dec_digits_div                                     137000000     0.020     0.021     0.023     0.024     0.024     0.024
dec_digits_math                                    150000000     0.018     0.019     0.022     0.028     0.032     0.032
dec_digits_stdio                                    60000000     0.049     0.050     0.052     0.055     0.055     0.055
dec_digits_less                                    322000000     0.008     0.009     0.009     0.009     0.010     0.010
```
But when dealing all integers up to 10^19, dec_digits_less takes the lead again -- 10% faster than it's rival.

### The second commit provides a faster implementation of dec_digits along with support for negative integers.
#### Results with new implementation  (K=7):
```
NAME                                                   COUNT       MIN       %50       %95       %99     %99.9    %99.99
------------------------------------------------------------------------------------------------------------------------
dec_digits_lib_unsigned                           4258000000         0         0         0         0         0         0
dec_digits_lib_signed                             3370000000         0         0         0         0         0         0
dec_digits_branch                                  441000000     0.006     0.006     0.006     0.006     0.007     0.007
dec_digits_div                                     257000000     0.011     0.011     0.011     0.012     0.012     0.012
dec_digits_math                                    164000000     0.018     0.018     0.018     0.018     0.018     0.018
dec_digits_stdio                                    70000000     0.042     0.043     0.044     0.045     0.045     0.045
dec_digits_less                                    386000000     0.007     0.007     0.007     0.008     0.008     0.008
```
The previous dec_digits_lib is now dec_digits_branch.

New dec_digits unsigned overload is about 9.6x faster than previous.
And the signed overload is about 7.6x faster.

#### Results with new implementation  (K=19):
```
NAME                                                   COUNT       MIN       %50       %95       %99     %99.9    %99.99
------------------------------------------------------------------------------------------------------------------------
dec_digits_lib_unsigned                           4286000000         0         0         0         0         0         0
dec_digits_lib_signed                             3364000000         0         0         0         0         0         0
dec_digits_branch                                  263000000      0.01     0.011     0.011     0.012     0.013     0.013
dec_digits_div                                     130000000     0.022     0.023     0.023     0.023     0.024     0.024
dec_digits_math                                    150000000     0.018      0.02      0.02      0.02      0.02      0.02
dec_digits_stdio                                    57000000     0.052     0.053     0.055     0.055     0.055     0.055
dec_digits_less                                    308000000     0.009     0.009      0.01      0.01      0.01      0.01
```
Unsigned overload about 16x faster.
Signed overload about 12.8x faster