### PR TITLE
fix(bm): fix random dist range parameter error

### DIFF
--- a/bench/Util.bm.cpp
+++ b/bench/Util.bm.cpp
@@ -55,7 +55,7 @@ std::vector<std::int64_t> generate_mixed_digit_nums(std::int64_t N, int K) noexc
         digit_dists.emplace_back(util::pow10(i), util::pow10(i+1) - 1u);
     }
 
-    std::uniform_int_distribution<int> selector_dist(0, digit_dists.size());
+    std::uniform_int_distribution<int> selector_dist(0, digit_dists.size()-1u);
 
     std::vector<std::int64_t> res;
     res.reserve(N);


### PR DESCRIPTION
The uniform_int_distribution construction parameters form a closed range (i.e. inclusive range). selector_dist should only generate integers to digit_dists.size()-1 so fix that.