### PR TITLE
feat(timer): Allow limiting the work done by dispatch

### DIFF
--- a/toolbox/io/Reactor.cpp
+++ b/toolbox/io/Reactor.cpp
@@ -95,7 +95,7 @@ int Reactor::poll(CyclTime now, Duration timeout)
     work += dispatch(now, buf, n);
     // Low priority timers are only dispatched during empty cycles.
     if (work == 0) {
-        work += tqs_[Low].dispatch(now);
+        work += tqs_[Low].dispatch(now, 1);
     }
     // End of cycle hooks.
     if (work > 0) {

--- a/toolbox/io/Timer.hpp
+++ b/toolbox/io/Timer.hpp
@@ -17,6 +17,7 @@
 #ifndef TOOLBOX_IO_TIMER_HPP
 #define TOOLBOX_IO_TIMER_HPP
 
+#include <limits>
 #include <toolbox/sys/Time.hpp>
 #include <toolbox/util/Slot.hpp>
 
@@ -167,7 +168,7 @@ class TOOLBOX_API TimerQueue {
     }
     // clang-format on
 
-    int dispatch(CyclTime now);
+    int dispatch(CyclTime now, int max_work = std::numeric_limits<int>::max());
 
   private:
     Timer allocate(MonoTime expiry, Duration interval, TimerSlot slot);


### PR DESCRIPTION
Sometimes it is required that TimerQueue::dispatch finishes fast in a bounded amount of time while still making progress on the queued timers. In which case, you want dispatch to process a small number of queued
timers and then return back to caller.

Furthermore, limit the work done by low priority timer queue to just 1 in the reactor. This prevents too much time being taken by low priority timers if there are a lot of them eligible to be dispatched. They are low priority timers, so its ok if they are delayed by a little bit of time.

SDB-8174