### PR TITLE
fix(clang-tidy): Remove old option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,6 @@ Checks:
   '-*,bugprone-use-after-move,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-override,readability-braces-around-statements,readability-deleted-default,readability-identifier-naming'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle: file
 CheckOptions:
   - key: readability-identifier-naming.EnumConstantCase


### PR DESCRIPTION
`AnalyzeTemporaryDtors` has been deprecated for a while and has now been removed so having this option now breaks clang-tidy.