### PR TITLE
feat: Add random int generating function

### DIFF
--- a/bench/Map.bm.cpp
+++ b/bench/Map.bm.cpp
@@ -13,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <toolbox/util/Random.hpp>
 #include <toolbox/util/RobinHood.hpp>
 
 #include <toolbox/bm.hpp>
 
 #include <map>
-#include <random>
 #include <unordered_map>
 
 // This benchmark is designed to measure random insertions and removals in a map of packed-sized
@@ -37,14 +37,10 @@ struct Elem {
 
 vector<int> make_rand_data(int range, size_t count)
 {
-    random_device rd;
-    mt19937 gen{rd()};
-    uniform_int_distribution<> dis{1, range};
-
     vector<int> data;
     data.reserve(count);
     for (size_t i{0}; i < count; ++i) {
-        data.push_back(dis(gen));
+        data.push_back(randint(1, range));
     }
     return data;
 }

--- a/bench/Util.bm.cpp
+++ b/bench/Util.bm.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <toolbox/util/Random.hpp>
 #include <toolbox/util/Utility.hpp>
 #include <toolbox/util/Math.hpp>
 
@@ -22,7 +23,6 @@
 #include <array>
 #include <cmath>
 #include <cstdio>
-#include <random>
 #include <vector>
 
 TOOLBOX_BENCHMARK_MAIN
@@ -42,28 +42,19 @@ constexpr array BoolArray{
 
 // K must be within the range [0,19]
 std::vector<std::int64_t> generate_mixed_digit_nums(std::int64_t N, int K) noexcept {
-    std::random_device dev;
-    std::mt19937_64 rng(dev());
-
-    // Create K distributions allowing for random number generation of up to 10^K,
-    // e.g. for K=3, the following distributions would be created:
-    //      1 - 9
-    //      10 - 99
-    //      100 - 999
-    std::vector<std::uniform_int_distribution<std::int64_t>> digit_dists;
-    for (int i = 0; i < K; i++) {
-        digit_dists.emplace_back(util::pow10(i), util::pow10(i+1) - 1u);
-    }
-
-    std::uniform_int_distribution<int> selector_dist(0, digit_dists.size()-1u);
-
     std::vector<std::int64_t> res;
     res.reserve(N);
 
     for(std::int64_t i = 0; i < N; i++) {
-        int dist_index = selector_dist(rng);
-        auto& selected_dist = digit_dists[dist_index];
-        res.push_back(selected_dist(rng));
+        int num_of_digits = randint(1, K);
+
+        // e.g. if num_of_digits=3
+        // lr := 10^(3-1) = 100
+        // ur := 10^3 - 1 = 999
+        std::int64_t lr = util::pow10(num_of_digits-1);
+        std::int64_t ur = util::pow10(num_of_digits) - 1u;
+
+        res.push_back(randint(lr, ur));
     }
 
     return res;

--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -107,6 +107,7 @@ set(lib_SOURCES
   util/IntTypes.cpp
   util/Math.cpp
   util/Options.cpp
+  util/Random.cpp
   util/RefCount.cpp
   util/RingBuffer.cpp
   util/RobinHood.cpp
@@ -242,6 +243,7 @@ set(test_SOURCES
   util/IntTypes.ut.cpp
   util/Math.ut.cpp
   util/Options.ut.cpp
+  util/Random.ut.cpp
   util/RefCount.ut.cpp
   util/RingBuffer.ut.cpp
   util/Slot.ut.cpp

--- a/toolbox/util/Random.cpp
+++ b/toolbox/util/Random.cpp
@@ -1,0 +1,34 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2024 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Random.hpp"
+
+#include <random>
+
+namespace toolbox {
+inline namespace util {
+
+namespace {
+thread_local std::mt19937_64 mt19937_64_rng_ {std::random_device{}()};
+} // namespace
+
+std::mt19937_64& mt19937_64_rng() noexcept
+{
+    return mt19937_64_rng_;
+}
+
+} // namespace util
+} // namespace toolbox

--- a/toolbox/util/Random.hpp
+++ b/toolbox/util/Random.hpp
@@ -1,0 +1,39 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2024 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOOLBOX_UTIL_RANDOM_HPP
+#define TOOLBOX_UTIL_RANDOM_HPP
+
+#include <toolbox/Config.h>
+
+#include <random>
+
+namespace toolbox {
+inline namespace util {
+
+TOOLBOX_API std::mt19937_64& mt19937_64_rng() noexcept;
+
+template <class IntT>
+IntT randint(IntT a, IntT b) {
+    std::mt19937_64& rng_engine = mt19937_64_rng();
+    std::uniform_int_distribution<IntT> dist(a, b);
+    return dist(rng_engine);
+}
+
+} // namespace util
+} // namespace toolbox
+
+#endif // TOOLBOX_UTIL_RANDOM_HPP

--- a/toolbox/util/Random.ut.cpp
+++ b/toolbox/util/Random.ut.cpp
@@ -1,0 +1,61 @@
+// The Reactive C++ Toolbox.
+// Copyright (C) 2013-2019 Swirly Cloud Limited
+// Copyright (C) 2024 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Random.hpp"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace toolbox;
+
+BOOST_AUTO_TEST_SUITE(RandomSuite)
+
+BOOST_AUTO_TEST_CASE(RandIntCase)
+{
+    constexpr int lower_bound = 0;
+    constexpr int upper_bound = 100;
+
+    vector<int> rand_ints;
+    for (int i = 0; i < 100; i++) {
+        rand_ints.push_back(randint(lower_bound, upper_bound));
+        std::cout << rand_ints.back() << '\n';
+    }
+
+    for (int num : rand_ints) {
+        BOOST_CHECK_GE(num, lower_bound);
+        BOOST_CHECK_LE(num, upper_bound);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(RandIntNegativeCase)
+{
+    constexpr int lower_bound = -100;
+    constexpr int upper_bound = 100;
+
+    vector<int> rand_ints;
+    for (int i = 0; i < 100; i++) {
+        rand_ints.push_back(randint(lower_bound, upper_bound));
+        std::cout << rand_ints.back() << '\n';
+    }
+
+    for (int num : rand_ints) {
+        BOOST_CHECK_GE(num, lower_bound);
+        BOOST_CHECK_LE(num, upper_bound);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Random number generation is ocurring more often in code. Random number generation is mainly done by
constructing and making use of std::random_device and std::mt19937. However, construction of these 2 objects is very expensive and should not be done regularly.

This commit adds an easy to use function for random number generation.
It also has good performance because it avoids constructing std::random_device and std::mt19937 each time.

SDB-7525