### PR TITLE
chore: Remove catch-all overload of OStaticStream

### DIFF
--- a/toolbox/util/Exception.cpp
+++ b/toolbox/util/Exception.cpp
@@ -56,7 +56,7 @@ void Exception::to_json(ostream& os, int code, const char* message)
 
 ErrMsg& err_msg() noexcept
 {
-    err_msg_.reset();
+    err_msg_.os_.reset();
     return err_msg_;
 }
 

--- a/toolbox/util/Exception.hpp
+++ b/toolbox/util/Exception.hpp
@@ -17,6 +17,7 @@
 #ifndef TOOLBOX_UTIL_EXCEPTION_HPP
 #define TOOLBOX_UTIL_EXCEPTION_HPP
 
+#include <string_view>
 #include <toolbox/util/Stream.hpp>
 
 namespace toolbox {
@@ -25,7 +26,19 @@ inline namespace util {
 /// Maximum error message length.
 constexpr std::size_t MaxErrSize{511};
 
-using ErrMsg = OStaticStream<MaxErrSize>;
+struct ErrMsg {
+    OStaticStream<MaxErrSize> os_;
+    operator std::string_view() const noexcept {
+        return os_.str();
+    }
+};
+
+template <typename ValueT>
+ErrMsg& operator<<(ErrMsg& err, ValueT&& val)
+{
+    err.os_ << std::forward<ValueT>(val);
+    return err;
+}
 
 class TOOLBOX_API Exception : public std::runtime_error {
   public:

--- a/toolbox/util/Stream.hpp
+++ b/toolbox/util/Stream.hpp
@@ -194,10 +194,6 @@ class OStaticStream final : public std::ostream {
     std::size_t size() const noexcept { return buf_.size(); }
 
     std::string_view str() const noexcept { return buf_.str(); }
-    operator std::string_view() const noexcept
-    {
-        return buf_.str();
-    } // NOLINT(hicpp-explicit-conversions)
     /// Reset the current position back to the beginning of the buffer.
     void reset() noexcept
     {
@@ -208,13 +204,6 @@ class OStaticStream final : public std::ostream {
   private:
     StaticStreamBuf<MaxN> buf_;
 };
-
-template <std::size_t MaxN, typename ValueT>
-auto& operator<<(OStaticStream<MaxN>& os, ValueT&& val)
-{
-    static_cast<std::ostream&>(os) << std::forward<ValueT>(val);
-    return os;
-}
 
 using OStreamJoiner = std::experimental::ostream_joiner<char>;
 

--- a/toolbox/util/Stream.ut.cpp
+++ b/toolbox/util/Stream.ut.cpp
@@ -46,7 +46,9 @@ BOOST_AUTO_TEST_CASE(OStaticStreamCase)
 
     os.reset();
     BOOST_CHECK(!!os);
-    BOOST_CHECK_EQUAL((os << "test").str(), "test");
+
+    os << "test";
+    BOOST_CHECK_EQUAL(os.str(), "test");
 }
 
 BOOST_AUTO_TEST_CASE(OStreamJoinerCase)


### PR DESCRIPTION
This an issue because if we attempt to create an custom overloaded operator<< for OStaticStream then it results in ambiguous call compiler error as there are now 2 valid overloads (first is catch-all in toolbox, and 2nd our custom defined one).

The catch-all overload mainly exists to ensure that after several streaming operations, OStaticStream& (ref) is returned. This then allows the OStaticStream& to be implicity converted to a string. For example, consider an expression like so: err_msg() << a << b << c;

If the catch-all overload did not exist, then this expression would return a 'std::ostream&' rather than 'OStaticStream&'. This would prevent the stream from being turned into a string implicitly as std::ostream& is not implicitly convertible to a string_view.

It is only 'err_msg()' that relies on this behaviour. Thus, 'ErrMsg' has now been promoted to a strong type, and implements the functionality it requires rather than burdening a generic type like OStaticStream. And so, the catch-all overload of OStaticStream, as well as implicit conversion to string_view can be removed.

SDB-8506