### PR TITLE
chore: replace the now removed buffer_cast

### DIFF
--- a/toolbox/http/Parser.hpp
+++ b/toolbox/http/Parser.hpp
@@ -66,7 +66,7 @@ class BasicParser {
     std::size_t parse(CyclTime /*now*/, ConstBuffer buf)
     {
         static http_parser_settings settings{make_settings()};
-        const auto rc = http_parser_execute(&parser_, &settings, buffer_cast<const char*>(buf),
+        const auto rc = http_parser_execute(&parser_, &settings, static_cast<const char*>(buf.data()),
                                             buffer_size(buf));
         const auto err = static_cast<http_errno>(parser_.http_errno);
         if (err != HPE_OK) {

--- a/toolbox/http/Stream.cpp
+++ b/toolbox/http/Stream.cpp
@@ -36,7 +36,7 @@ StreamBuf::int_type StreamBuf::overflow(int_type c) noexcept
 {
     if (c != traits_type::eof()) {
         auto buf = buf_.prepare(pcount_ + 1);
-        pbase_ = buffer_cast<char*>(buf);
+        pbase_ = static_cast<char*>(buf.data());
         pbase_[pcount_++] = c;
     }
     return c;
@@ -45,7 +45,7 @@ StreamBuf::int_type StreamBuf::overflow(int_type c) noexcept
 streamsize StreamBuf::xsputn(const char_type* s, streamsize count) noexcept
 {
     auto buf = buf_.prepare(pcount_ + count);
-    pbase_ = buffer_cast<char*>(buf);
+    pbase_ = static_cast<char*>(buf.data());
     memcpy(pbase_ + pcount_, s, count);
     pcount_ += count;
     return count;

--- a/toolbox/io/Buffer.cpp
+++ b/toolbox/io/Buffer.cpp
@@ -47,7 +47,7 @@ void Buffer::consume(std::size_t count) noexcept
 
 ConstBuffer advance(ConstBuffer buf, std::size_t n) noexcept
 {
-    const auto* const data = buffer_cast<const char*>(buf);
+    const auto* const data = static_cast<const char*>(buf.data());
     const std::size_t size = buffer_size(buf);
     const auto offset = std::min(n, size);
     return {data + offset, size - offset};
@@ -55,7 +55,7 @@ ConstBuffer advance(ConstBuffer buf, std::size_t n) noexcept
 
 MutableBuffer advance(MutableBuffer buf, std::size_t n) noexcept
 {
-    auto* const data = buffer_cast<char*>(buf);
+    auto* const data = static_cast<char*>(buf.data());
     const std::size_t size = buffer_size(buf);
     const auto offset = std::min(n, size);
     return {data + offset, size - offset};

--- a/toolbox/io/File.hpp
+++ b/toolbox/io/File.hpp
@@ -165,13 +165,13 @@ inline std::size_t read(int fd, void* buf, std::size_t len)
 /// Read from a file descriptor.
 inline ssize_t read(int fd, MutableBuffer buf, std::error_code& ec) noexcept
 {
-    return read(fd, buffer_cast<void*>(buf), buffer_size(buf), ec);
+    return read(fd, static_cast<void*>(buf.data()), buffer_size(buf), ec);
 }
 
 /// Read from a file descriptor.
 inline std::size_t read(int fd, MutableBuffer buf) noexcept
 {
-    return read(fd, buffer_cast<void*>(buf), buffer_size(buf));
+    return read(fd, static_cast<void*>(buf.data()), buffer_size(buf));
 }
 
 /// Write to a file descriptor.
@@ -197,13 +197,13 @@ inline std::size_t write(int fd, const void* buf, std::size_t len)
 /// Write to a file descriptor.
 inline ssize_t write(int fd, ConstBuffer buf, std::error_code& ec) noexcept
 {
-    return write(fd, buffer_cast<const void*>(buf), buffer_size(buf), ec);
+    return write(fd, static_cast<const void*>(buf.data()), buffer_size(buf), ec);
 }
 
 /// Write to a file descriptor.
 inline std::size_t write(int fd, ConstBuffer buf)
 {
-    return write(fd, buffer_cast<const void*>(buf), buffer_size(buf));
+    return write(fd, static_cast<const void*>(buf.data()), buffer_size(buf));
 }
 
 /// File control.

--- a/toolbox/io/Stream.cpp
+++ b/toolbox/io/Stream.cpp
@@ -26,7 +26,7 @@ StreamBuf::int_type StreamBuf::overflow(int_type c) noexcept
 {
     if (c != traits_type::eof()) {
         auto buf = buf_.prepare(pcount_ + 1);
-        pbase_ = buffer_cast<char*>(buf);
+        pbase_ = static_cast<char*>(buf.data());
         pbase_[pcount_++] = c;
     }
     return c;
@@ -35,7 +35,7 @@ StreamBuf::int_type StreamBuf::overflow(int_type c) noexcept
 streamsize StreamBuf::xsputn(const char_type* s, streamsize count) noexcept
 {
     auto buf = buf_.prepare(pcount_ + count);
-    pbase_ = buffer_cast<char*>(buf);
+    pbase_ = static_cast<char*>(buf.data());
     memcpy(pbase_ + pcount_, s, count);
     pcount_ += count;
     return count;

--- a/toolbox/net/Frame.hpp
+++ b/toolbox/net/Frame.hpp
@@ -78,7 +78,7 @@ constexpr std::uint16_t get_length(const char* buf, std::endian net_byte_order) 
 inline std::uint16_t get_length(ConstBuffer buf, std::endian net_byte_order) noexcept
 {
     assert(buffer_size(buf) >= 2);
-    return get_length(buffer_cast<const char*>(buf), net_byte_order);
+    return get_length(static_cast<const char*>(buf.data()), net_byte_order);
 }
 
 /// Writes a binary-encoded 2 byte integer to the output buffer.
@@ -99,7 +99,7 @@ inline void put_length(char* buf, std::uint16_t len, std::endian net_byte_order)
 inline void put_length(MutableBuffer buf, std::uint16_t len, std::endian net_byte_order) noexcept
 {
     assert(buffer_size(buf) >= 2);
-    put_length(buffer_cast<char*>(buf), len, net_byte_order);
+    put_length(static_cast<char*>(buf.data()), len, net_byte_order);
 }
 
 /// Calls the function object for each message encapsulated in a length-prefixed frame.
@@ -114,7 +114,7 @@ std::size_t parse_frame(ConstBuffer buf, FnT fn, std::endian net_byte_order)
 {
     std::size_t consumed{0};
     for (;;) {
-        const auto* data = buffer_cast<const char*>(buf);
+        const auto* data = static_cast<const char*>(buf.data());
         const std::size_t size = buffer_size(buf);
         if (size < sizeof(std::uint16_t)) {
             break;

--- a/toolbox/net/Frame.ut.cpp
+++ b/toolbox/net/Frame.ut.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(ParseFrameCase)
     size_t consumed{0};
     auto fn = [&](auto msg) {
         ++msg_count;
-        msg_data.append(buffer_cast<const char*>(msg), buffer_size(msg));
+        msg_data.append(static_cast<const char*>(msg.data()), buffer_size(msg));
     };
 
     consumed += parse_frame("\003"sv, fn, endian::little);

--- a/toolbox/net/Socket.hpp
+++ b/toolbox/net/Socket.hpp
@@ -373,13 +373,13 @@ inline std::size_t recv(int sockfd, void* buf, std::size_t len, int flags)
 /// Receive a message from a socket.
 inline ssize_t recv(int sockfd, MutableBuffer buf, int flags, std::error_code& ec) noexcept
 {
-    return recv(sockfd, buffer_cast<void*>(buf), buffer_size(buf), flags, ec);
+    return recv(sockfd, static_cast<void*>(buf.data()), buffer_size(buf), flags, ec);
 }
 
 /// Receive a message from a socket.
 inline std::size_t recv(int sockfd, MutableBuffer buf, int flags)
 {
-    return recv(sockfd, buffer_cast<void*>(buf), buffer_size(buf), flags);
+    return recv(sockfd, static_cast<void*>(buf.data()), buffer_size(buf), flags);
 }
 
 /// Receive a message from a socket.
@@ -436,14 +436,14 @@ template <typename EndpointT>
 inline ssize_t recvfrom(int sockfd, MutableBuffer buf, int flags, EndpointT& ep,
                         std::error_code& ec) noexcept
 {
-    return recvfrom(sockfd, buffer_cast<void*>(buf), buffer_size(buf), flags, ep, ec);
+    return recvfrom(sockfd, static_cast<void*>(buf.data()), buffer_size(buf), flags, ep, ec);
 }
 
 /// Receive a message from a socket.
 template <typename EndpointT>
 inline std::size_t recvfrom(int sockfd, MutableBuffer buf, int flags, EndpointT& ep)
 {
-    return recvfrom(sockfd, buffer_cast<void*>(buf), buffer_size(buf), flags, ep);
+    return recvfrom(sockfd, static_cast<void*>(buf.data()), buffer_size(buf), flags, ep);
 }
 
 /// Send a message on a socket.
@@ -470,13 +470,13 @@ inline std::size_t send(int sockfd, const void* buf, std::size_t len, int flags)
 /// Send a message on a socket.
 inline ssize_t send(int sockfd, ConstBuffer buf, int flags, std::error_code& ec) noexcept
 {
-    return send(sockfd, buffer_cast<const void*>(buf), buffer_size(buf), flags, ec);
+    return send(sockfd, static_cast<const void*>(buf.data()), buffer_size(buf), flags, ec);
 }
 
 /// Send a message on a socket.
 inline std::size_t send(int sockfd, ConstBuffer buf, int flags)
 {
-    return send(sockfd, buffer_cast<const void*>(buf), buffer_size(buf), flags);
+    return send(sockfd, static_cast<const void*>(buf.data()), buffer_size(buf), flags);
 }
 
 /// Send a message on a socket.
@@ -522,7 +522,7 @@ template <typename EndpointT>
 inline ssize_t sendto(int sockfd, ConstBuffer buf, int flags, const EndpointT& ep,
                       std::error_code& ec) noexcept
 {
-    return sendto(sockfd, buffer_cast<const void*>(buf), buffer_size(buf), flags, *ep.data(),
+    return sendto(sockfd, static_cast<const void*>(buf.data()), buffer_size(buf), flags, *ep.data(),
                   ep.size(), ec);
 }
 
@@ -530,7 +530,7 @@ inline ssize_t sendto(int sockfd, ConstBuffer buf, int flags, const EndpointT& e
 template <typename EndpointT>
 inline std::size_t sendto(int sockfd, ConstBuffer buf, int flags, const EndpointT& ep)
 {
-    return sendto(sockfd, buffer_cast<const void*>(buf), buffer_size(buf), flags, *ep.data(),
+    return sendto(sockfd, static_cast<const void*>(buf.data()), buffer_size(buf), flags, *ep.data(),
                   ep.size());
 }
 


### PR DESCRIPTION
buffer_cast was removed in boost 1.87