### PR TITLE
chore: Remove final instance of buffer_cast

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -56,7 +56,7 @@ jobs:
         run: cd build && make -j2 tb-doc
 
       - name: Upload documentation
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: doc
           path: build/doc/html

--- a/toolbox/io/Buffer.hpp
+++ b/toolbox/io/Buffer.hpp
@@ -28,7 +28,6 @@ inline namespace io {
 using ConstBuffer = boost::asio::const_buffer;
 using MutableBuffer = boost::asio::mutable_buffer;
 
-using boost::asio::buffer_cast;
 using boost::asio::buffer_size;
 
 class TOOLBOX_API Buffer {


### PR DESCRIPTION
buffer_cast removed in boost 1.87. All uses of it have been removed in a previous commit but this was missed.

Also fixes the GH Pages action.