### PR TITLE
feat!: Extend slots to allow return values

### DIFF
--- a/example/HttpServ.cpp
+++ b/example/HttpServ.cpp
@@ -38,7 +38,7 @@ void on_bar(const Request& /*req*/, http::OStream& os)
 
 class ExampleApp final : public App {
   public:
-    using Slot = BasicSlot<const Request&, http::OStream&>;
+    using Slot = BasicSlot<void(const Request&, http::OStream&)>;
     using SlotMap = std::map<std::string, Slot>;
 
     ~ExampleApp() override = default;

--- a/toolbox/io/Hook.hpp
+++ b/toolbox/io/Hook.hpp
@@ -27,7 +27,7 @@ inline namespace io {
 
 struct Hook
 : boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>> {
-    using Slot = BasicSlot<CyclTime>;
+    using Slot = BasicSlot<void(CyclTime)>;
     explicit Hook(Slot slot) noexcept
     : slot{slot}
     {

--- a/toolbox/io/Inotify.hpp
+++ b/toolbox/io/Inotify.hpp
@@ -137,7 +137,7 @@ class TOOLBOX_API Inotify {
 class TOOLBOX_API FileWatcher {
   public:
     using Path = std::filesystem::path;
-    using Slot = BasicSlot<const Path&, int, std::uint32_t>;
+    using Slot = BasicSlot<void(const Path&, int, std::uint32_t)>;
 
     FileWatcher(Reactor& r, Inotify& inotify);
     ~FileWatcher() = default;

--- a/toolbox/io/Reactor.hpp
+++ b/toolbox/io/Reactor.hpp
@@ -29,7 +29,7 @@ inline namespace io {
 constexpr Duration NoTimeout{-1};
 enum class Priority { High = 0, Low = 1 };
 
-using IoSlot = BasicSlot<CyclTime, int, unsigned>;
+using IoSlot = BasicSlot<void(CyclTime, int, unsigned)>;
 
 class TOOLBOX_API Reactor : public Waker {
   public:

--- a/toolbox/io/Timer.hpp
+++ b/toolbox/io/Timer.hpp
@@ -32,7 +32,7 @@ inline namespace io {
 
 class Timer;
 class TimerQueue;
-using TimerSlot = BasicSlot<CyclTime, Timer&>;
+using TimerSlot = BasicSlot<void(CyclTime, Timer&)>;
 
 class TOOLBOX_API Timer {
     friend class TimerQueue;

--- a/toolbox/util/Slot.ut.cpp
+++ b/toolbox/util/Slot.ut.cpp
@@ -29,16 +29,16 @@ void foo(int& x)
 } // namespace
 
 // Test constexpr.
-static_assert(BasicSlot<int>{} == BasicSlot<int>{});
-static_assert(BasicSlot<int>{}.empty());
-static_assert(!BasicSlot<int>{});
+static_assert(BasicSlot<void(int)>{} == BasicSlot<void(int)>{});
+static_assert(BasicSlot<void(int)>{}.empty());
+static_assert(!BasicSlot<void(int)>{});
 
 BOOST_AUTO_TEST_SUITE(SlotSuite)
 
 BOOST_AUTO_TEST_CASE(SlotEmptyCase)
 {
-    BOOST_CHECK(BasicSlot<int>{}.empty());
-    BOOST_CHECK(!BasicSlot<int>{});
+    BOOST_CHECK(BasicSlot<void(int)>{}.empty());
+    BOOST_CHECK(!BasicSlot<void(int)>{});
 }
 
 BOOST_AUTO_TEST_CASE(SlotFreeFunCase)
@@ -138,12 +138,22 @@ BOOST_AUTO_TEST_CASE(SlotRvalueFunCase)
     int x{2};
     auto fn = [&x](int&& y) { x = x + y; };
 
-    BasicSlot<int&&> cb = toolbox::bind(&fn);
+    BasicSlot<void(int&&)> cb = toolbox::bind(&fn);
     cb(3);
     BOOST_CHECK_EQUAL(x, 5);
     int&& m = 6;
     cb.invoke(std::move(m));
     BOOST_CHECK_EQUAL(x, 11);
+}
+
+BOOST_AUTO_TEST_CASE(SlotReturnValue)
+{
+    auto fn = [](int x) { return x+2; };
+    BasicSlot<int(int)> cb = toolbox::bind(&fn);
+    BOOST_CHECK_EQUAL(cb(3), 5);
+    BOOST_CHECK_EQUAL(cb(5), 7);
+    BOOST_CHECK_EQUAL(cb.invoke(3), 5);
+    BOOST_CHECK_EQUAL(cb.invoke(5), 7);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/toolbox/util/Traits.hpp
+++ b/toolbox/util/Traits.hpp
@@ -39,9 +39,9 @@ struct FunctionTraits<ReturnT (*)(ArgsT...)> {
     template <std::size_t i>
     using ArgType = std::tuple_element_t<i, std::tuple<ArgsT...>>;
 
-    // Apply parameter pack to template.
+    // Apply function signature to template.
     template <template <typename...> typename TemplT>
-    using Pack = TemplT<ArgsT...>;
+    using Apply = TemplT<ReturnT(ArgsT...)>;
 };
 
 /// Specialisation for noexcept free functions.

--- a/toolbox/util/Traits.ut.cpp
+++ b/toolbox/util/Traits.ut.cpp
@@ -39,7 +39,6 @@ BOOST_AUTO_TEST_CASE(TraitsFreeFunCase)
     foo(0, 0, 0);
 
     using Traits = FunctionTraits<decltype(&foo)>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, void>));
@@ -47,7 +46,6 @@ BOOST_AUTO_TEST_CASE(TraitsFreeFunCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsFunctorCase)
@@ -57,7 +55,6 @@ BOOST_AUTO_TEST_CASE(TraitsFunctorCase)
     };
 
     using Traits = FunctionTraits<Test>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, Test>));
@@ -65,7 +62,6 @@ BOOST_AUTO_TEST_CASE(TraitsFunctorCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsConstFunctorCase)
@@ -75,7 +71,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstFunctorCase)
     };
 
     using Traits = FunctionTraits<Test>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, Test>));
@@ -83,7 +78,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstFunctorCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsConstNoexceptFunctorCase)
@@ -93,7 +87,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstNoexceptFunctorCase)
     };
 
     using Traits = FunctionTraits<Test>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, Test>));
@@ -101,7 +94,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstNoexceptFunctorCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsNoexceptFunctorCase)
@@ -111,7 +103,6 @@ BOOST_AUTO_TEST_CASE(TraitsNoexceptFunctorCase)
     };
 
     using Traits = FunctionTraits<Test>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, Test>));
@@ -119,7 +110,6 @@ BOOST_AUTO_TEST_CASE(TraitsNoexceptFunctorCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsLambdaCase)
@@ -127,7 +117,6 @@ BOOST_AUTO_TEST_CASE(TraitsLambdaCase)
     auto fn = [](short, int, long) -> double { return 0.0; };
 
     using Traits = FunctionTraits<decltype(fn)>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, remove_cv_t<decltype(fn)>>));
@@ -135,7 +124,6 @@ BOOST_AUTO_TEST_CASE(TraitsLambdaCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsConstLambdaCase)
@@ -143,7 +131,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstLambdaCase)
     const auto fn = [](short, int, long) -> double { return 0.0; };
 
     using Traits = FunctionTraits<decltype(fn)>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, remove_const_t<decltype(fn)>>));
@@ -151,7 +138,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstLambdaCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsConstNoexceptLambdaCase)
@@ -159,7 +145,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstNoexceptLambdaCase)
     const auto fn = [](short, int, long) noexcept -> double { return 0.0; };
 
     using Traits = FunctionTraits<decltype(fn)>;
-    using Tuple = Traits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<Traits::ReturnType, double>));
     BOOST_CHECK((is_same_v<Traits::ClassType, remove_const_t<decltype(fn)>>));
@@ -167,7 +152,6 @@ BOOST_AUTO_TEST_CASE(TraitsConstNoexceptLambdaCase)
     BOOST_CHECK((is_same_v<Traits::ArgType<0>, short>));
     BOOST_CHECK((is_same_v<Traits::ArgType<1>, int>));
     BOOST_CHECK((is_same_v<Traits::ArgType<2>, long>));
-    BOOST_CHECK_EQUAL(tuple_size_v<Tuple>, 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsMemFunCase)
@@ -178,23 +162,19 @@ BOOST_AUTO_TEST_CASE(TraitsMemFunCase)
     };
 
     using FooTraits = FunctionTraits<decltype(&Test::foo)>;
-    using FooTuple = FooTraits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<FooTraits::ReturnType, short>));
     BOOST_CHECK((is_same_v<FooTraits::ClassType, Test>));
     BOOST_CHECK_EQUAL(FooTraits::Arity, 1);
     BOOST_CHECK((is_same_v<FooTraits::ArgType<0>, int>));
-    BOOST_CHECK_EQUAL(tuple_size_v<FooTuple>, 1U);
 
     using BarTraits = FunctionTraits<decltype(&Test::bar)>;
-    using BarTuple = BarTraits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<BarTraits::ReturnType, long>));
     BOOST_CHECK((is_same_v<BarTraits::ClassType, Test>));
     BOOST_CHECK_EQUAL(BarTraits::Arity, 2);
     BOOST_CHECK((is_same_v<BarTraits::ArgType<0>, double>));
     BOOST_CHECK((is_same_v<BarTraits::ArgType<1>, double>));
-    BOOST_CHECK_EQUAL(tuple_size_v<BarTuple>, 2U);
 }
 
 BOOST_AUTO_TEST_CASE(TraitsConstMemFunCase)
@@ -205,23 +185,19 @@ BOOST_AUTO_TEST_CASE(TraitsConstMemFunCase)
     };
 
     using FooTraits = FunctionTraits<decltype(&Test::foo)>;
-    using FooTuple = FooTraits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<FooTraits::ReturnType, short>));
     BOOST_CHECK((is_same_v<FooTraits::ClassType, Test>));
     BOOST_CHECK_EQUAL(FooTraits::Arity, 1);
     BOOST_CHECK((is_same_v<FooTraits::ArgType<0>, int>));
-    BOOST_CHECK_EQUAL(tuple_size_v<FooTuple>, 1U);
 
     using BarTraits = FunctionTraits<decltype(&Test::bar)>;
-    using BarTuple = BarTraits::Pack<tuple>;
 
     BOOST_CHECK((is_same_v<BarTraits::ReturnType, long>));
     BOOST_CHECK((is_same_v<BarTraits::ClassType, Test>));
     BOOST_CHECK_EQUAL(BarTraits::Arity, 2);
     BOOST_CHECK((is_same_v<BarTraits::ArgType<0>, double>));
     BOOST_CHECK((is_same_v<BarTraits::ArgType<1>, double>));
-    BOOST_CHECK_EQUAL(tuple_size_v<BarTuple>, 2U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
BasicSlot template now takes callable signature as template parameter, just like std::function

SDB-8765