### PR TITLE
fix(build): link libatomic when using Clang ≥ 17

### DIFF
--- a/toolbox/CMakeLists.txt
+++ b/toolbox/CMakeLists.txt
@@ -132,13 +132,13 @@ set(lib_SOURCES
 
 add_library(tb-core-static STATIC ${lib_SOURCES})
 set_target_properties(tb-core-static PROPERTIES OUTPUT_NAME tb_core)
-target_link_libraries(tb-core-static pthread)
+target_link_libraries(tb-core-static atomic pthread)
 install(TARGETS tb-core-static DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT static)
 
 if(TOOLBOX_BUILD_SHARED)
   add_library(tb-core-shared SHARED ${lib_SOURCES})
   set_target_properties(tb-core-shared PROPERTIES OUTPUT_NAME tb_core)
-  target_link_libraries(tb-core-shared pthread)
+  target_link_libraries(tb-core-shared atomic pthread)
   install(TARGETS tb-core-shared DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT shared)
 endif()
 


### PR DESCRIPTION
GCC 15's libstdc++ now emits calls to __atomic_compare_exchange for certain 16-byte CAS operations (e.g. Boost.Lockfree's tagged_index). Clang does not add libatomic automatically, so the link step fails with "undefined reference to __atomic_compare_exchange".

Add 'atomic' to target_link_libraries so Clang builds succeed on all x86-64 configurations.

SDB-9349