### PR TITLE
feat: Use buffer pool for logging

### DIFF
--- a/toolbox/sys/Log.hpp
+++ b/toolbox/sys/Log.hpp
@@ -46,7 +46,11 @@ class Log {
     , level_{level}
     , os_{log_stream()}
     {
-        os_.set_storage(os_.make_storage());
+        LogMsgPtr storage;
+        if (!log_buf_pool().pop(storage)) [[unlikely]] {
+            storage = LogStream::make_storage();
+        }
+        os_.set_storage(std::move(storage));
     }
     ~Log()
     {

--- a/toolbox/sys/Log.ut.cpp
+++ b/toolbox/sys/Log.ut.cpp
@@ -44,6 +44,9 @@ struct TestLogger final : Logger {
     void do_write_log(WallTime /*ts*/, LogLevel level, int /*tid*/, LogMsgPtr&& msg,
                       size_t size) noexcept override
     {
+        const auto finally = make_finally([&]() noexcept {
+            log_buf_pool().bounded_push(std::move(msg));
+        });
         last_level = level;
         last_msg.assign(static_cast<const char*>(msg.get()), size);
     }

--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -17,13 +17,15 @@
 #ifndef TOOLBOX_SYS_LOGGER_HPP
 #define TOOLBOX_SYS_LOGGER_HPP
 
-#include <boost/lockfree/queue.hpp>
-#include <thread>
-
 #include <toolbox/sys/Limits.hpp>
 #include <toolbox/sys/Time.hpp>
 #include <toolbox/util/Storage.hpp>
 #include <toolbox/util/Concepts.hpp>
+
+#include <boost/lockfree/queue.hpp>
+#include <boost/lockfree/stack.hpp>
+
+#include <thread>
 
 namespace toolbox {
 inline namespace sys {
@@ -50,6 +52,11 @@ enum class LogLevel : int {
 };
 
 using LogMsgPtr = StoragePtr<MaxLogLine>;
+inline constexpr std::size_t LogBufPoolCapacity = 64;
+using LogBufPool = boost::lockfree::stack<LogMsgPtr, boost::lockfree::capacity<LogBufPoolCapacity>>;
+
+/// A pool of log buffers, eliminating the need for dynamic memory allocations when logging
+TOOLBOX_API LogBufPool& log_buf_pool() noexcept;
 
 /// Null logger. This logger does nothing and is effectively /dev/null.
 TOOLBOX_API Logger& null_logger() noexcept;


### PR DESCRIPTION
Eliminates dynamic allocations

The Log class now attempts to acquire a buffer from this pool before falling back to dynamic allocation. Various logger implementations (NullLogger, StdLogger, SysLogger, AsyncLogger) are updated to return the buffers to the pool after use.

SDB-10043