### PR TITLE
chore: Update to cpp26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 
 set(CMAKE_C_STANDARD 11)
 # Emits -std=gnu++1z on OSX which is not working as expected.
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(COMMON_WARN "-Wall -Werror -Wextra -Wstrict-aliasing=2 -Wno-error=deprecated-declarations")

--- a/toolbox/io/Event.hpp
+++ b/toolbox/io/Event.hpp
@@ -27,7 +27,9 @@ struct MsgEvent {
     int type;
     char data[1524];
 };
-static_assert(std::is_standard_layout_v<MsgEvent> && std::is_trivial_v<MsgEvent>);
+static_assert(std::is_standard_layout_v<MsgEvent>
+              && std::is_trivially_default_constructible_v<MsgEvent>
+              && std::is_trivially_copyable_v<MsgEvent>);
 static_assert(sizeof(MsgEvent) + sizeof(std::int64_t) == 1536);
 
 template <typename DataT>

--- a/toolbox/util/Concepts.hpp
+++ b/toolbox/util/Concepts.hpp
@@ -41,8 +41,13 @@ concept Streamable = requires (T& os) {
     os.write(std::declval<const char*>(), std::declval<std::size_t>());
 };
 
-template <class T>
+template <typename T>
 concept Pointer = std::is_pointer_v<T>;
+
+// Type can be mapped directly to and from IPC/SBE binary buffers.
+template <typename T>
+concept WireMappable = std::is_standard_layout_v<T> && std::is_trivially_default_constructible_v<T>
+    && std::is_trivially_copyable_v<T>;
 
 } // namespace util
 } // namespace toolbox

--- a/toolbox/util/IntTypes.hpp
+++ b/toolbox/util/IntTypes.hpp
@@ -251,8 +251,7 @@ struct TOOLBOX_PACKED IntWrapper {
 
 static_assert(IntWrapper<Int32Policy>{1} == IntWrapper<Int32Policy>{1});
 static_assert(IntWrapper<Int32Policy>{1} != IntWrapper<Int32Policy>{2});
-static_assert(std::is_standard_layout_v<IntWrapper<Int32Policy>>
-              && std::is_trivial_v<IntWrapper<Int32Policy>>);
+static_assert(WireMappable<IntWrapper<Int32Policy>>);
 static_assert(sizeof(IntWrapper<Int16Policy>) == 2, "must be specific size");
 static_assert(sizeof(IntWrapper<Int32Policy>) == 4, "must be specific size");
 static_assert(sizeof(IntWrapper<Int64Policy>) == 8, "must be specific size");


### PR DESCRIPTION
## chore: Update to cpp26

## chore: Add new WireMappable concept

And replaces uses of deprecated std::is_trivial.
Replaces with the recommended replacement:
```
  _GLIBCXX26_DEPRECATED_SUGGEST("is_trivially_default_constructible_v && is_trivially_copyable_v")
```

90% of places where we use this check, we are essentially verifying that we can use it with our IPC setup. So I have added a helper concept to better show the meaning.

SDB-11394