### PR TITLE
fix: avoid heap allocation in to_string for IntWrapper types

### DIFF
--- a/toolbox/util/String.hpp
+++ b/toolbox/util/String.hpp
@@ -18,6 +18,7 @@
 #define TOOLBOX_UTIL_STRING_HPP
 
 #include <toolbox/util/Concepts.hpp>
+#include <toolbox/util/IntTypes.hpp>
 #include <toolbox/util/TypeTraits.hpp>
 
 #include <charconv>
@@ -66,6 +67,15 @@ std::string to_string(ValueT&& val)
 // clang-format on
 {
     return std::to_string(val);
+}
+
+template <typename PolicyT>
+// clang-format off
+requires Arithmetic<typename PolicyT::ValueType>
+std::string to_string(IntWrapper<PolicyT> val)
+// clang-format on
+{
+    return std::to_string(val.count());
 }
 
 template <std::size_t SizeN>

--- a/toolbox/util/String.ut.cpp
+++ b/toolbox/util/String.ut.cpp
@@ -53,6 +53,13 @@ BOOST_AUTO_TEST_CASE(ToStringCase)
     BOOST_CHECK_EQUAL(to_string("foo"sv), "foo"s);
     BOOST_CHECK_EQUAL(stoi(to_string(12345)), 12345);
     BOOST_CHECK_EQUAL(stod(to_string(12345.67)), 12345.67);
+
+    // IntWrapper-derived types (Id16/Id32/Id64) must resolve to this overload rather than the
+    // generic stringstream-based template, including at magnitudes that exceed the 15-character
+    // small-string-optimisation threshold in libstdc++ (e.g. epoch-microsecond serial ids).
+    BOOST_CHECK_EQUAL(to_string(Id64{123456789}), "123456789"s);
+    BOOST_CHECK_EQUAL(to_string(Id64{-123456789}), "-123456789"s);
+    BOOST_CHECK_EQUAL(to_string(Id64{1783894459839125}), "1783894459839125"s);
 }
 
 BOOST_AUTO_TEST_CASE(LtrimCopyCase)


### PR DESCRIPTION
IntWrapper-derived types (Id16/Id32/Id64) fell through to the generic stringstream-based to_string template, since IntWrapper is a class type and fails the Arithmetic constraint on the fast std::to_string overload. This heap-allocates on every call for 16-digit production serial ids, which exceed libstdc++'s 15-character SSO threshold.

Adds a dedicated overload that unwraps to the underlying integer and calls std::to_string directly, removing the stringstream construction, locale acquisition, and stringbuf allocation with no call-site changes required.

SDB-11523