### PR TITLE
feat(bench): make map benchmarks representative

### DIFF
--- a/bench/Map.bm.cpp
+++ b/bench/Map.bm.cpp
@@ -18,11 +18,25 @@
 
 #include <toolbox/bm.hpp>
 
-#include <map>
-#include <unordered_map>
+#include <boost/unordered/unordered_flat_map.hpp>
 
-// This benchmark is designed to measure random insertions and removals in a map of packed-sized
-// data with a small keyspace (<100).
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+// Compares toolbox::RobinMap against boost::unordered_flat_map (the proposed replacement) and
+// std::unordered_map (a stable baseline) across successful and unsuccessful lookups, insertion
+// into an initially empty map, steady-state churn, and full iteration.
+//
+// Keys are distinct integers, shuffled once per run and shared by every benchmark and
+// implementation, so all three implementations always compare against identical inputs while
+// varying between runs. Setup happens outside the timed ranges, results are consumed so
+// operations cannot be optimised away, and final cardinality is checked.
+//
+// Benchmark names follow <implementation>_<operation>_<entries>_<value shape>.
 
 TOOLBOX_BENCHMARK_MAIN
 
@@ -31,99 +45,401 @@ using namespace toolbox;
 
 namespace {
 
-struct Elem {
+/// Small mapped value representing an id, index, or pointer-sized payload.
+using SmallValue = int64_t;
+
+/// Large mapped value comparable to a packet-sized payload.
+struct LargeValue {
     char data[1472];
 };
 
-vector<int> make_rand_data(int range, size_t count)
+/// Number of passes over the key set per timed batch, to amortise timer overhead.
+constexpr size_t Sweeps{8};
+
+/// Returns count * 2 distinct keys, shuffled with the toolbox's shared RNG: the first count keys
+/// populate each map, and the remaining count keys are guaranteed-absent probes.
+vector<int> make_keys(size_t count)
 {
-    vector<int> data;
-    data.reserve(count);
+    vector<int> keys(count * 2);
+    ranges::iota(keys, 0);
+    ranges::shuffle(keys, mt19937_64_rng());
+    return keys;
+}
+
+const auto Keys64 = make_keys(64);
+const auto Keys4096 = make_keys(4096);
+
+/// Populates m with the first half of keys; setup only, outside any timed range.
+template <typename MapT>
+void populate(MapT& m, const vector<int>& keys)
+{
+    const auto count{keys.size() / 2};
     for (size_t i{0}; i < count; ++i) {
-        data.push_back(randint(1, range));
+        m.try_emplace(keys[i]);
     }
-    return data;
 }
 
-const int KeyRange{64};
-const size_t RandCount{4096};
-
-// Use the same random sequence for each benchmark.
-const auto RandData = make_rand_data(KeyRange, RandCount);
-
-TOOLBOX_BENCHMARK(std_map_insert_erase)
+/// Successful lookups on a fully populated map that never mutates.
+template <typename MapT>
+void run_find_hit(bm::Context& ctx, const vector<int>& keys)
 {
-    map<int, Elem> m;
+    const auto count{keys.size() / 2};
+    MapT m;
+    populate(m, keys);
 
-    size_t i{0};
+    size_t hits{0};
+    size_t ops{0};
     while (ctx) {
-        for ([[maybe_unused]] auto _ : ctx.range(100)) {
-            m[i++ % RandData.size()];
-            m.erase(i++ % RandData.size());
+        {
+            // Named so its lifetime spans the sweeps: batch records the elapsed time per
+            // operation when it leaves scope.
+            auto batch{ctx.range(static_cast<int>(Sweeps * count))};
+            for (size_t sweep{0}; sweep < Sweeps; ++sweep) {
+                for (size_t i{0}; i < count; ++i) {
+                    if (m.find(keys[i]) != m.end()) {
+                        ++hits;
+                    }
+                }
+                // Stop the optimiser caching lookups across sweeps of the same keys.
+                bm::clobber_memory();
+            }
+        }
+        ops += Sweeps * count;
+        bm::do_not_optimise(hits);
+    }
+    if (m.size() != count || hits != ops) {
+        throw runtime_error{"find hit benchmark invariant broken"};
+    }
+}
+
+/// Unsuccessful lookups on a fully populated map that never mutates.
+template <typename MapT>
+void run_find_miss(bm::Context& ctx, const vector<int>& keys)
+{
+    const auto count{keys.size() / 2};
+    MapT m;
+    populate(m, keys);
+
+    size_t hits{0};
+    while (ctx) {
+        {
+            auto batch{ctx.range(static_cast<int>(Sweeps * count))};
+            for (size_t sweep{0}; sweep < Sweeps; ++sweep) {
+                for (size_t i{0}; i < count; ++i) {
+                    if (m.find(keys[count + i]) != m.end()) {
+                        ++hits;
+                    }
+                }
+                bm::clobber_memory();
+            }
+        }
+        bm::do_not_optimise(hits);
+    }
+    if (m.size() != count || hits != 0) {
+        throw runtime_error{"find miss benchmark invariant broken"};
+    }
+}
+
+/// Insertion into an initially empty map. The timed region covers growth from empty to count
+/// entries, including rehashes; construction and destruction of the map are not timed.
+template <typename MapT>
+void run_insert(bm::Context& ctx, const vector<int>& keys)
+{
+    const auto count{keys.size() / 2};
+    while (ctx) {
+        MapT m;
+        for (auto i : ctx.range(static_cast<int>(count))) {
+            m.try_emplace(keys[static_cast<size_t>(i)]);
+        }
+        if (m.size() != count) {
+            throw runtime_error{"insert benchmark invariant broken"};
         }
     }
 }
 
-TOOLBOX_BENCHMARK(std_unordered_map_insert_erase)
+/// Steady-state churn: each operation erases a present key and inserts an absent key, sliding a
+/// count-sized window over the key universe so cardinality never changes.
+template <typename MapT>
+void run_churn(bm::Context& ctx, const vector<int>& keys)
 {
-    unordered_map<int, Elem> m;
+    const auto count{keys.size() / 2};
+    MapT m;
+    populate(m, keys);
 
-    size_t i{0};
+    size_t erased{0};
+    size_t ops{0};
+    size_t erase_idx{0};
+    size_t insert_idx{count};
     while (ctx) {
-        for ([[maybe_unused]] auto _ : ctx.range(100)) {
-            m[i++ % RandData.size()];
-            m.erase(i++ % RandData.size());
+        for ([[maybe_unused]] auto _ : ctx.range(static_cast<int>(count))) {
+            erased += m.erase(keys[erase_idx]);
+            m.try_emplace(keys[insert_idx]);
+            // Wrap with predictable branches: modulo would add a division per timed operation.
+            if (++erase_idx == keys.size()) {
+                erase_idx = 0;
+            }
+            if (++insert_idx == keys.size()) {
+                insert_idx = 0;
+            }
         }
+        ops += count;
+        bm::do_not_optimise(erased);
+    }
+    if (m.size() != count || erased != ops) {
+        throw runtime_error{"churn benchmark invariant broken"};
     }
 }
 
-TOOLBOX_BENCHMARK(robin_map_insert_erase)
+/// Full iteration over a fully populated map, consuming a checksum of keys and values.
+template <typename MapT>
+void run_iterate(bm::Context& ctx, const vector<int>& keys)
 {
-    RobinMap<int, Elem> m;
+    const auto count{keys.size() / 2};
+    MapT m;
+    for (size_t i{0}; i < count; ++i) {
+        m.try_emplace(keys[i], static_cast<typename MapT::mapped_type>(keys[i]));
+    }
 
-    size_t i{0};
+    uint64_t sum{0};
     while (ctx) {
-        for ([[maybe_unused]] auto _ : ctx.range(100)) {
-            m[i++ % RandData.size()];
-            m.erase(i++ % RandData.size());
+        {
+            auto batch{ctx.range(static_cast<int>(Sweeps * count))};
+            for (size_t sweep{0}; sweep < Sweeps; ++sweep) {
+                for (const auto& kv : m) {
+                    sum += static_cast<uint64_t>(kv.first) + static_cast<uint64_t>(kv.second);
+                }
+                bm::clobber_memory();
+            }
         }
+        bm::do_not_optimise(sum);
+    }
+    if (m.size() != count) {
+        throw runtime_error{"iterate benchmark invariant broken"};
     }
 }
 
-TOOLBOX_BENCHMARK(std_map_immutable)
-{
-    map<int, Elem> m;
+// --- find_hit: successful lookups on a fully populated map, small mapped value ---
 
-    size_t i{0};
-    while (ctx) {
-        for ([[maybe_unused]] auto _ : ctx.range(100)) {
-            m[i++ % RandData.size()];
-        }
-    }
+TOOLBOX_BENCHMARK(robin_map_find_hit_64_small)
+{
+    run_find_hit<RobinMap<int, SmallValue>>(ctx, Keys64);
 }
 
-TOOLBOX_BENCHMARK(std_unordered_map_immutable)
+TOOLBOX_BENCHMARK(boost_flat_map_find_hit_64_small)
 {
-    unordered_map<int, Elem> m;
-
-    size_t i{0};
-    while (ctx) {
-        for ([[maybe_unused]] auto _ : ctx.range(100)) {
-            m[i++ % RandData.size()];
-        }
-    }
+    run_find_hit<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys64);
 }
 
-TOOLBOX_BENCHMARK(robin_map_immutable)
+TOOLBOX_BENCHMARK(std_unordered_map_find_hit_64_small)
 {
-    RobinMap<int, Elem> m;
+    run_find_hit<unordered_map<int, SmallValue>>(ctx, Keys64);
+}
 
-    size_t i{0};
-    while (ctx) {
-        for ([[maybe_unused]] auto _ : ctx.range(100)) {
-            m[i++ % RandData.size()];
-        }
-    }
+TOOLBOX_BENCHMARK(robin_map_find_hit_4096_small)
+{
+    run_find_hit<RobinMap<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_find_hit_4096_small)
+{
+    run_find_hit<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_find_hit_4096_small)
+{
+    run_find_hit<unordered_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+// --- find_miss: unsuccessful lookups on a fully populated map, small mapped value ---
+
+TOOLBOX_BENCHMARK(robin_map_find_miss_64_small)
+{
+    run_find_miss<RobinMap<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_find_miss_64_small)
+{
+    run_find_miss<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_find_miss_64_small)
+{
+    run_find_miss<unordered_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(robin_map_find_miss_4096_small)
+{
+    run_find_miss<RobinMap<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_find_miss_4096_small)
+{
+    run_find_miss<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_find_miss_4096_small)
+{
+    run_find_miss<unordered_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+// --- iterate: full pass over a fully populated map, small mapped value ---
+
+TOOLBOX_BENCHMARK(robin_map_iterate_64_small)
+{
+    run_iterate<RobinMap<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_iterate_64_small)
+{
+    run_iterate<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_iterate_64_small)
+{
+    run_iterate<unordered_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(robin_map_iterate_4096_small)
+{
+    run_iterate<RobinMap<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_iterate_4096_small)
+{
+    run_iterate<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_iterate_4096_small)
+{
+    run_iterate<unordered_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+// --- insert: fill an initially empty map, small mapped value ---
+
+TOOLBOX_BENCHMARK(robin_map_insert_64_small)
+{
+    run_insert<RobinMap<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_insert_64_small)
+{
+    run_insert<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_insert_64_small)
+{
+    run_insert<unordered_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(robin_map_insert_4096_small)
+{
+    run_insert<RobinMap<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_insert_4096_small)
+{
+    run_insert<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_insert_4096_small)
+{
+    run_insert<unordered_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+// --- insert: fill an initially empty map, large mapped value ---
+
+TOOLBOX_BENCHMARK(robin_map_insert_64_large)
+{
+    run_insert<RobinMap<int, LargeValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_insert_64_large)
+{
+    run_insert<boost::unordered_flat_map<int, LargeValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_insert_64_large)
+{
+    run_insert<unordered_map<int, LargeValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(robin_map_insert_4096_large)
+{
+    run_insert<RobinMap<int, LargeValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_insert_4096_large)
+{
+    run_insert<boost::unordered_flat_map<int, LargeValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_insert_4096_large)
+{
+    run_insert<unordered_map<int, LargeValue>>(ctx, Keys4096);
+}
+
+// --- churn: steady-state erase-and-insert, small mapped value ---
+
+TOOLBOX_BENCHMARK(robin_map_churn_64_small)
+{
+    run_churn<RobinMap<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_churn_64_small)
+{
+    run_churn<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_churn_64_small)
+{
+    run_churn<unordered_map<int, SmallValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(robin_map_churn_4096_small)
+{
+    run_churn<RobinMap<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_churn_4096_small)
+{
+    run_churn<boost::unordered_flat_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_churn_4096_small)
+{
+    run_churn<unordered_map<int, SmallValue>>(ctx, Keys4096);
+}
+
+// --- churn: steady-state erase-and-insert, large mapped value ---
+
+TOOLBOX_BENCHMARK(robin_map_churn_64_large)
+{
+    run_churn<RobinMap<int, LargeValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_churn_64_large)
+{
+    run_churn<boost::unordered_flat_map<int, LargeValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_churn_64_large)
+{
+    run_churn<unordered_map<int, LargeValue>>(ctx, Keys64);
+}
+
+TOOLBOX_BENCHMARK(robin_map_churn_4096_large)
+{
+    run_churn<RobinMap<int, LargeValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(boost_flat_map_churn_4096_large)
+{
+    run_churn<boost::unordered_flat_map<int, LargeValue>>(ctx, Keys4096);
+}
+
+TOOLBOX_BENCHMARK(std_unordered_map_churn_4096_large)
+{
+    run_churn<unordered_map<int, LargeValue>>(ctx, Keys4096);
 }
 
 } // namespace


### PR DESCRIPTION
The previous tb-map-bench workloads could not support a RobinMap replacement decision: sequence indices drove operations instead of the prepared random keys, insert and erase touched disjoint key sets so every erase missed and the "immutable" cases used operator[], which inserts on first touch.
Replaced them with single-purpose workloads - successful and unsuccessful find, insertion into an initially empty map, steady-state churn that preserves cardinality, and full iteration with a consumed checksum - each run for RobinMap,
boost::unordered_flat_map (the proposed replacement) and std::unordered_map (baseline) against identical inputs: distinct integer keys, deterministically shuffled with a fixed seed, at 64 and 4096 entries, with small and large mapped values for the mutating workloads. Setup is excluded from timed ranges, results are consumed so operations cannot be optimised away, and final cardinality is checked.

PLT-233