### PR TITLE
SDB-11550: expose deferred-dispose state in disposer

### DIFF
--- a/toolbox/io/Disposer.hpp
+++ b/toolbox/io/Disposer.hpp
@@ -57,6 +57,10 @@ class BasicDisposer {
     /// Returns true if the lock is held or the object has been disposed.
     bool is_locked() const noexcept { return locks_ > 0; }
 
+    /// Returns true if disposal has been requested while a lock was held and is deferred until
+    /// the last lock is released.
+    bool is_dispose_deferred() const noexcept { return dispose_; }
+
     /// Returns a lock that prevents the disposer instance from being deleted while the lock is
     /// held.
     [[nodiscard]] auto lock_this(CyclTime now) noexcept

--- a/toolbox/io/Disposer.ut.cpp
+++ b/toolbox/io/Disposer.ut.cpp
@@ -23,6 +23,7 @@ using namespace toolbox;
 
 namespace {
 struct Disposer : BasicDisposer<Disposer> {
+    using BasicDisposer<Disposer>::is_dispose_deferred;
     using BasicDisposer<Disposer>::is_locked;
     using BasicDisposer<Disposer>::lock_this;
     void dispose_now(CyclTime now) noexcept
@@ -43,25 +44,31 @@ BOOST_AUTO_TEST_CASE(DisposerCase)
     const auto now = CyclTime::now();
     Disposer d;
     BOOST_CHECK(!d.is_locked());
+    BOOST_CHECK(!d.is_dispose_deferred());
     BOOST_CHECK_EQUAL(d.disposed, 0);
     {
         auto lock = d.lock_this(now);
         BOOST_CHECK(d.is_locked());
+        BOOST_CHECK(!d.is_dispose_deferred());
     }
     BOOST_CHECK(!d.is_locked());
+    BOOST_CHECK(!d.is_dispose_deferred());
     BOOST_CHECK_EQUAL(d.disposed, 0);
     {
         auto outer_lock = d.lock_this(now);
         BOOST_CHECK(d.is_locked());
         {
             auto inner_lock = d.lock_this(now);
+            BOOST_CHECK(!d.is_dispose_deferred());
             d.dispose(now);
             BOOST_CHECK(d.is_locked());
+            BOOST_CHECK(d.is_dispose_deferred());
             BOOST_CHECK_EQUAL(d.disposed, 0);
         }
         // And again.
         d.dispose(now);
         BOOST_CHECK(d.is_locked());
+        BOOST_CHECK(d.is_dispose_deferred());
         BOOST_CHECK_EQUAL(d.disposed, 0);
     }
     BOOST_CHECK_EQUAL(d.disposed, 1);


### PR DESCRIPTION
BasicDisposer records a dispose request made while a lock is held in its private dispose_ flag, but derived classes cannot observe it. The FIX connection needs this state so send loops that hold a disposer lock across a message batch can stop sending once a mid-loop write failure has requested disposal, instead of duplicating the flag in the derived class.

Adds a protected is_dispose_deferred() accessor alongside is_locked() and extends the unit test to cover it.

SDB-11550