### PR TITLE
feat(docs): fix stale comments in Options, Logger and Runner

### DIFF
--- a/toolbox/io/Runner.hpp
+++ b/toolbox/io/Runner.hpp
@@ -33,7 +33,7 @@ using HistogramPtr = std::unique_ptr<Histogram>;
 /// MetricCallbackFunction implementer is responsible for deleting the Histogram.
 using MetricCallbackFunction
     = std::function<void(CyclTime now, HistogramPtr&& time_hist, HistogramPtr&& work_hist)>;
-/// LoopCallbackFunction called at end of each Reactor loop, indicating micros taken and work done.
+/// LoopCallbackFunction called after each Reactor poll that processed work.
 using LoopCallbackFunction = std::function<void(CyclTime now)>;
 
 class TOOLBOX_API ReactorRunner {

--- a/toolbox/sys/Logger.hpp
+++ b/toolbox/sys/Logger.hpp
@@ -68,8 +68,8 @@ TOOLBOX_API bool log_warming_mode_enabled() noexcept;
 /// Null logger. This logger does nothing and is effectively /dev/null.
 TOOLBOX_API Logger& null_logger() noexcept;
 
-/// Standard logger. This logger writes to stdout if the log level is greater than LogWarn, and
-/// stdout otherwise.
+/// Standard logger. This logger writes to stderr if the severity is Error or higher and stdout
+/// otherwise.
 TOOLBOX_API Logger& std_logger() noexcept;
 
 /// System logger. This logger calls syslog().
@@ -106,8 +106,7 @@ inline Logger& set_logger(std::nullptr_t) noexcept
 /// before formatting the log message.
 TOOLBOX_API void write_log(WallTime ts, LogLevel level, LogMsgPtr&& msg, std::size_t size) noexcept;
 
-/// The Logger is implemented by types that may be woken-up, interrupted or otherwise notified
-/// asynchronously.
+/// The Logger is implemented by types that write log messages to a sink.
 class TOOLBOX_API Logger {
   public:
     Logger() noexcept = default;

--- a/toolbox/util/Options.cpp
+++ b/toolbox/util/Options.cpp
@@ -86,7 +86,6 @@ void Options::parse(int argc, const char* const argv[])
     }
 
     // Ensure all required parameters have been set.
-    // FIXME: but we're not checking required positional arguments?
     for (const auto& data : opts_) {
         visit(overloaded{[](const auto& /*def*/) {},
                          [&](const Value& arg) {


### PR DESCRIPTION
- Options.cpp: remove a FIXME questioning whether required positional arguments are checked; the loop immediately below it already does this and reports missing values.
- Logger.hpp: fix std_logger's doc comment, which named the wrong level and duplicated stdout for both branches.
- Logger.hpp: correct the base Logger class comment, which described async  wake-up and notify behaviour when it is in fact synchronus.
- Runner.hpp: fix LoopCallbackFunction's comment, the callback only receives CyclTime.